### PR TITLE
Add python 3.7 runtime for kubeless

### DIFF
--- a/stable/python/Dockerfile.3.7
+++ b/stable/python/Dockerfile.3.7
@@ -1,0 +1,24 @@
+FROM bitnami/minideb-runtimes:stretch
+
+# Install required system packages and dependencies
+RUN install_packages build-essential ca-certificates curl git libbz2-1.0 libc6 libffi6 libncurses5 libreadline7 libsqlite3-0 libssl1.1 libtinfo5 pkg-config unzip wget zlib1g
+RUN wget -nc -P /tmp/bitnami/pkg/cache/ https://downloads.bitnami.com/files/stacksmith/python-3.7.1-0-linux-amd64-debian-9.tar.gz && \
+    echo "4f1a47dc398b6942d328662b5a7719358fb7788afc746b0e4935ffb165140596  /tmp/bitnami/pkg/cache/python-3.7.1-0-linux-amd64-debian-9.tar.gz" | sha256sum -c - && \
+    tar -zxf /tmp/bitnami/pkg/cache/python-3.7.1-0-linux-amd64-debian-9.tar.gz -P --transform 's|^[^/]*/files|/opt/bitnami|' --wildcards '*/files' && \
+    rm -rf /tmp/bitnami/pkg/cache/python-3.7.1-0-linux-amd64-debian-9.tar.gz
+
+ENV BITNAMI_APP_NAME="python" \
+    BITNAMI_IMAGE_VERSION="3.7.1-r0" \
+    PATH="/opt/bitnami/python/bin:$PATH"
+
+RUN curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
+RUN python ./get-pip.py
+
+RUN pip install bottle==0.12.13 cherrypy==8.9.1 wsgi-request-logger prometheus_client
+
+WORKDIR /
+ADD kubeless.py .
+
+USER 1000
+
+CMD ["python", "/kubeless.py"]

--- a/stable/python/Makefile
+++ b/stable/python/Makefile
@@ -8,6 +8,9 @@ build3.4:
 build3.6:
 	docker build -t kubeless/python:3.6$$RUNTIME_TAG_MODIFIER -f Dockerfile.3.6 .
 
+build3.7:
+	docker build -t kubeless/python:3.7$$RUNTIME_TAG_MODIFIER -f Dockerfile.3.7 .
+
 push2.7:
 	docker push kubeless/python:2.7$$RUNTIME_TAG_MODIFIER
 
@@ -17,13 +20,16 @@ push3.4:
 push3.6:
 	docker push kubeless/python:3.6$$RUNTIME_TAG_MODIFIER
 
+push3.7:
+	docker push mbeacom/python:3.7$$RUNTIME_TAG_MODIFIER
+
 # Mandatory jobs
-build-all: build2.7 build3.4 build3.6
-push-all: push2.7 push3.4 push3.6
+build-all: build2.7 build3.4 build3.6 build3.7
+push-all: push2.7 push3.4 push3.6 push3.7
 
 # Testing jobs
-deploy: get-python get-python-deps get-python-custom-port get-python-34 get-python-36 get-python-url-deps scheduled-get-python timeout-python get-python-secrets post-python post-python-custom-port custom-get-python
-test: get-python-verify get-python-deps-verify get-python-custom-port-verify get-python-34-verify get-python-36-verify get-python-url-deps-verify scheduled-get-python-verify timeout-python-verify get-python-secrets-verify custom-get-python-verify post-python-verify post-python-custom-port-verify 
+deploy: get-python get-python-deps get-python-custom-port get-python-34 get-python-36 get-python-37 get-python-url-deps scheduled-get-python timeout-python get-python-secrets post-python post-python-custom-port custom-get-python
+test: get-python-verify get-python-deps-verify get-python-custom-port-verify get-python-34-verify get-python-36-verify get-python-37-verify get-python-url-deps-verify scheduled-get-python-verify timeout-python-verify get-python-secrets-verify custom-get-python-verify post-python-verify post-python-custom-port-verify
 
 get-python:
 	kubeless function deploy get-python --runtime python2.7 --handler helloget.foo --from-file examples/helloget.py
@@ -63,12 +69,19 @@ get-python-36-verify:
 	kubectl rollout status deployment/get-python-36 && sleep 2
 	kubeless function call get-python-36 |egrep hello.world
 
+get-python-37:
+	kubeless function deploy get-python-37 --runtime python3.7 --handler helloget.foo --from-file examples/helloget.py
+
+get-python-37-verify:
+	kubectl rollout status deployment/get-python-37 && sleep 2
+	kubeless function call get-python-37 |egrep hello.world
+
 get-python-url-deps:
 	kubeless function deploy get-python-url-deps --runtime python2.7 --handler helloget.foo --from-file https://raw.githubusercontent.com/kubeless/kubeless/v1.0.0-alpha.1/examples/python/hellowithdeps.py --dependencies https://raw.githubusercontent.com/kubeless/kubeless/v1.0.0-alpha.1/examples/python/requirements.txt
 
 get-python-url-deps-verify:
 	kubectl rollout status deployment/get-python-url-deps && sleep 2
-	kubeless function call get-python-url-deps |egrep Google	
+	kubeless function call get-python-url-deps |egrep Google
 
 scheduled-get-python:
 	kubeless function deploy scheduled-get-python --schedule "* * * * *" --runtime python2.7 --handler helloget.foo --from-file examples/helloget.py

--- a/stable/python/Makefile
+++ b/stable/python/Makefile
@@ -21,7 +21,7 @@ push3.6:
 	docker push kubeless/python:3.6$$RUNTIME_TAG_MODIFIER
 
 push3.7:
-	docker push mbeacom/python:3.7$$RUNTIME_TAG_MODIFIER
+	docker push kubeless/python:3.7$$RUNTIME_TAG_MODIFIER
 
 # Mandatory jobs
 build-all: build2.7 build3.4 build3.6 build3.7

--- a/stable/python/python.jsonnet
+++ b/stable/python/python.jsonnet
@@ -55,7 +55,7 @@
         command: "pip install --prefix=$KUBELESS_INSTALL_VOLUME -r $KUBELESS_DEPS_FILE"
       }, {
         phase: "runtime",
-        image: "kubeless/python-37@sha256:dbf616cb06a262482c00f5b53e1de17571924032e0ad000865ec6b5357ff35bf",
+        image: "kubeless/python@sha256:dbf616cb06a262482c00f5b53e1de17571924032e0ad000865ec6b5357ff35bf",
         env: {
           PYTHONPATH: "$(KUBELESS_INSTALL_VOLUME)/lib/python3.7/site-packages:$(KUBELESS_INSTALL_VOLUME)",
         },

--- a/stable/python/python.jsonnet
+++ b/stable/python/python.jsonnet
@@ -46,6 +46,21 @@
         },
       }],
     },
+    {
+      name: "python37",
+      version: "3.7",
+      images: [{
+        phase: "installation",
+        image: "python:3.7",
+        command: "pip install --prefix=$KUBELESS_INSTALL_VOLUME -r $KUBELESS_DEPS_FILE"
+      }, {
+        phase: "runtime",
+        image: "mbeacom/python-37@sha256:00bc8f1c6ca6ba7ca69ac3085f1d9c95a11f1faede7f8952fe30d10349b10d23",
+        env: {
+          PYTHONPATH: "$(KUBELESS_INSTALL_VOLUME)/lib/python3.7/site-packages:$(KUBELESS_INSTALL_VOLUME)",
+        },
+      }],
+    },
   ],
   depName: "requirements.txt",
   fileNameSuffix: ".py",

--- a/stable/python/python.jsonnet
+++ b/stable/python/python.jsonnet
@@ -55,7 +55,7 @@
         command: "pip install --prefix=$KUBELESS_INSTALL_VOLUME -r $KUBELESS_DEPS_FILE"
       }, {
         phase: "runtime",
-        image: "mbeacom/python-37@sha256:00bc8f1c6ca6ba7ca69ac3085f1d9c95a11f1faede7f8952fe30d10349b10d23",
+        image: "kubeless/python-37@sha256:dbf616cb06a262482c00f5b53e1de17571924032e0ad000865ec6b5357ff35bf",
         env: {
           PYTHONPATH: "$(KUBELESS_INSTALL_VOLUME)/lib/python3.7/site-packages:$(KUBELESS_INSTALL_VOLUME)",
         },


### PR DESCRIPTION
The goal of this PR is to add support for python 3.7 since it's now stable.

Tested against my fork image `mbeacom/python-37@sha256:00bc8f1c6ca6ba7ca69ac3085f1d9c95a11f1faede7f8952fe30d10349b10d23`