### PR TITLE
Add multipart/form-data content type support

### DIFF
--- a/stable/nodejs/kubeless.js
+++ b/stable/nodejs/kubeless.js
@@ -81,6 +81,8 @@ function modExecute(handler, req, res, end) {
         if (req.body.length > 0) {
             if (req.is('application/json')) {
                 data = JSON.parse(req.body.toString('utf-8'))
+            } else if (req.is('multipart/form-data')) {
+                data = req.body
             } else {
                 data = req.body.toString('utf-8')
             }


### PR DESCRIPTION
In order to read streams we need to stop converting the request.body into a string when the content type is multipart. By doing this, we are able to use libraries like multiparty or formidable to extract the file and additional fields.