### PR TITLE
Added image for DotnetCore 2.2 with metrics endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ artifacts/
 *.nuget.props
 *.nuget.targets
 .vscode/
+.idea/

--- a/stable/dotnetcore/Dockerfile
+++ b/stable/dotnetcore/Dockerfile
@@ -1,5 +1,5 @@
 # Image used only for build process
-FROM microsoft/dotnet:2.2-sdk AS build-env
+FROM microsoft/dotnet:2.1-sdk AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -13,7 +13,7 @@ COPY ./src/ ./
 RUN dotnet publish ./Kubeless.WebAPI/ -c Release -o out
 
 # Build runtime image
-FROM microsoft/dotnet:2.2-aspnetcore-runtime
+FROM microsoft/dotnet:2.1-aspnetcore-runtime
 WORKDIR /app
 COPY --from=build-env /app/Kubeless.WebAPI/out .
 # Kubeless.Functions reference

--- a/stable/dotnetcore/Dockerfile
+++ b/stable/dotnetcore/Dockerfile
@@ -1,5 +1,5 @@
 # Image used only for build process
-FROM microsoft/dotnet:2.1-sdk AS build-env
+FROM microsoft/dotnet:2.2-sdk AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -13,7 +13,7 @@ COPY ./src/ ./
 RUN dotnet publish ./Kubeless.WebAPI/ -c Release -o out
 
 # Build runtime image
-FROM microsoft/dotnet:2.1-aspnetcore-runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime
 WORKDIR /app
 COPY --from=build-env /app/Kubeless.WebAPI/out .
 # Kubeless.Functions reference

--- a/stable/dotnetcore/Dockerfile.2.2
+++ b/stable/dotnetcore/Dockerfile.2.2
@@ -1,0 +1,22 @@
+# Image used only for build process
+FROM microsoft/dotnet:2.2-sdk AS build-env
+WORKDIR /app
+
+# Copy csproj and restore as distinct layers
+COPY ./src/Kubeless.Core/*.csproj ./Kubeless.Core/
+COPY ./src/Kubeless.Functions/*.csproj ./Kubeless.Functions/
+COPY ./src/Kubeless.WebAPI/*.csproj ./Kubeless.WebAPI/
+RUN dotnet restore ./Kubeless.WebAPI/
+
+# Copy everything else and build in release mode
+COPY ./src/ ./
+RUN dotnet publish ./Kubeless.WebAPI/ -c Release -o out
+
+# Build runtime image
+FROM microsoft/dotnet:2.2-aspnetcore-runtime
+WORKDIR /app
+COPY --from=build-env /app/Kubeless.WebAPI/out .
+# Kubeless.Functions reference
+COPY --from=build-env /app/Kubeless.WebAPI/out/Kubeless.Functions.dll /usr/share/dotnet/store/x64/netcoreapp2.0/.
+
+ENTRYPOINT ["dotnet", "Kubeless.WebAPI.dll"]

--- a/stable/dotnetcore/Dockerfile.init
+++ b/stable/dotnetcore/Dockerfile.init
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-sdk
+FROM microsoft/dotnet:2.2-sdk
 
 WORKDIR /app
 

--- a/stable/dotnetcore/Dockerfile.init
+++ b/stable/dotnetcore/Dockerfile.init
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk
+FROM microsoft/dotnet:2.1-sdk
 
 WORKDIR /app
 

--- a/stable/dotnetcore/Dockerfile.init.2.2
+++ b/stable/dotnetcore/Dockerfile.init.2.2
@@ -1,0 +1,15 @@
+FROM microsoft/dotnet:2.2-sdk
+
+WORKDIR /app
+
+RUN dotnet new classlib -n project -o .
+RUN dotnet add package Kubeless.Functions
+RUN dotnet restore
+
+RUN mv /root/.dotnet /root/.nuget /
+RUN mkdir /.local/
+RUN chown 1000 /.dotnet /.nuget /.nuget/packages /.local
+
+ADD compile-function.sh .
+RUN chmod u+x compile-function.sh
+RUN chown 1000 compile-function.sh

--- a/stable/dotnetcore/Kubeless.sln
+++ b/stable/dotnetcore/Kubeless.sln
@@ -27,6 +27,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Functions", "Functions", "{
 		examples\namespaced-helloget.csproj = examples\namespaced-helloget.csproj
 		examples\timeout.cs = examples\timeout.cs
 		examples\timeout.csproj = examples\timeout.csproj
+		examples\err.cs = examples\err.cs
+		examples\err.csproj = examples\err.csproj
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docker", "Docker", "{CCBE6752-398A-4934-B276-9557032BF32E}"

--- a/stable/dotnetcore/Kubeless.sln
+++ b/stable/dotnetcore/Kubeless.sln
@@ -36,6 +36,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docker", "Docker", "{CCBE67
 		Dockerfile.init = Dockerfile.init
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Config", "Config", "{061F4D26-FC00-4EDD-8395-33BE4B70C3F6}"
+ProjectSection(SolutionItems) = preProject
+	Makefile = Makefile
+	dotnetcore.jsonnet = dotnetcore.jsonnet
+	OWNERS = OWNERS
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/stable/dotnetcore/Kubeless.sln
+++ b/stable/dotnetcore/Kubeless.sln
@@ -34,6 +34,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docker", "Docker", "{CCBE67
 		compile-function.sh = compile-function.sh
 		Dockerfile = Dockerfile
 		Dockerfile.init = Dockerfile.init
+		Dockerfile.2.2 = Dockerfile.2.2
+		Dockerfile.init.2.2 = Dockerfile.init.2.2
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Config", "Config", "{061F4D26-FC00-4EDD-8395-33BE4B70C3F6}"

--- a/stable/dotnetcore/Makefile
+++ b/stable/dotnetcore/Makefile
@@ -126,3 +126,25 @@ get-dotnetcore-dependency-verify20:
 	
 get-dotnetcore-dependency-clean20:
 	kubeless function delete get-dotnetcore-dependency20
+	
+	
+# build docker
+
+REPOSITORY		:= lennartquerter
+RUNTIME_NAME	:= ${REPOSITORY}/kubless_runtime_dotnetcore22
+COMPILE_NAME	:= ${REPOSITORY}/kubless_compile_dotnetcore22
+TAG				:= $(shell git log -1 --pretty=%H)
+RUNTIME_IMG		:= ${RUNTIME_NAME}
+COMPILE_IMG		:= ${COMPILE_NAME}
+
+build-runtime:
+	docker build -f Dockerfile.2.2 -t ${RUNTIME_IMG}:${TAG} .
+
+push-runtime:
+	docker push ${RUNTIME_IMG}:${TAG}
+
+build-compile:
+	docker build -f Dockerfile.init.2.2 -t ${COMPILE_IMG}:$(TAG) .
+	
+push-compile:
+	docker push ${COMPILE_IMG}:${TAG}

--- a/stable/dotnetcore/Makefile
+++ b/stable/dotnetcore/Makefile
@@ -1,37 +1,102 @@
 # Testing jobs
-deploy: get-dotnetcore get-dotnetcore-dependency post-dotnetcore get-dotnetcore-namespaced get-dotnetcore20 get-dotnetcore-dependency20
-test: get-dotnetcore-verify get-dotnetcore-dependency-verify post-dotnetcore-verify get-dotnetcore-namespaced-verify get-dotnetcore-verify20 get-dotnetcore-dependency-verify20
+deploy: get-dotnetcore get-dotnetcore-dependency post-dotnetcore get-dotnetcore-namespaced 
+# get-dotnetcore21 get-dotnetcore-dependency21 post-dotnetcore21 get-dotnetcore-namespaced21 
+# get-dotnetcore20 get-dotnetcore-dependency20
 
-# .NET Core 2.1
+test: get-dotnetcore-verify get-dotnetcore-dependency-verify post-dotnetcore-verify get-dotnetcore-namespaced-verify 
+# get-dotnetcore-verify21 get-dotnetcore-dependency-verify21 post-dotnetcore-verify21 get-dotnetcore-namespaced-verify21 
+# get-dotnetcore-verify20 get-dotnetcore-dependency-verify20
+
+clean: get-dotnetcore-clean get-dotnetcore-dependency-clean post-dotnetcore-clean get-dotnetcore-namespaced-clean
+# get-dotnetcore-verify21-clean get-dotnetcore-dependency-verify21-clean post-dotnetcore-verify21-clean get-dotnetcore-namespaced-verify21-clean 
+# get-dotnetcore-verify20-clean get-dotnetcore-dependency-verify20-clean
+
+
+# .NET Core 2.2
 
 get-dotnetcore:
-	kubeless function deploy get-dotnetcore --runtime dotnetcore2.1 --handler module.handler --from-file examples/helloget.cs
+	kubeless function deploy get-dotnetcore --runtime dotnetcore2.2 --handler module.handler --from-file examples/helloget.cs
 
 get-dotnetcore-verify:
 	kubectl rollout status deployment/get-dotnetcore && sleep 2
 	kubeless function call get-dotnetcore |egrep hello.world
 	kubeless function top --function get-dotnetcore --out yaml |egrep "Function does not expose metrics" 
 
+get-dotnetcore-clean:
+    kubless function delete get-dotnetcore
+    
 get-dotnetcore-dependency:
-	kubeless function deploy get-dotnetcore-dependency --runtime dotnetcore2.1 --handler module.handler --from-file examples/dependency-yaml.cs --dependencies examples/dependency-yaml.csproj
+	kubeless function deploy get-dotnetcore-dependency --runtime dotnetcore2.2 --handler module.handler --from-file examples/dependency-yaml.cs --dependencies examples/dependency-yaml.csproj
 
 get-dotnetcore-dependency-verify:
 	kubectl rollout status deployment/get-dotnetcore-dependency && sleep 2
 	kubeless function call get-dotnetcore-dependency |egrep Name:\ Michael
 
+get-dotnetcore-dependency-clean:
+    kubless function delete get-dotnetcore-dependency
+
 post-dotnetcore:
-	kubeless function deploy post-dotnetcore --runtime dotnetcore2.1 --handler module.handler --from-file examples/hellowithdata.cs
+	kubeless function deploy post-dotnetcore --runtime dotnetcore2.2 --handler module.handler --from-file examples/hellowithdata.cs
 
 post-dotnetcore-verify:
 	kubectl rollout status deployment/post-dotnetcore && sleep 2
 	kubeless function call post-dotnetcore --data '{"it-s": "alive"}'|egrep "it.*alive"
 	
+post-dotnetcore-clean:
+    kubless function delete post-dotnetcore
+
 get-dotnetcore-namespaced:
-	kubeless function deploy get-dotnetcore-namespaced --runtime dotnetcore2.1 --handler module.handler --from-file examples/namespaced-helloget.cs
+	kubeless function deploy get-dotnetcore-namespaced --runtime dotnetcore2.2 --handler module.handler --from-file examples/namespaced-helloget.cs
 
 get-dotnetcore-namespaced-verify:
 	kubectl rollout status deployment/get-dotnetcore-namespaced && sleep 2
 	kubeless function call get-dotnetcore-namespaced |egrep hello.world
+
+get-dotnetcore-namespaced-clean:
+    kubless function delete get-dotnetcore-namespaced
+
+# .NET Core 2.1
+
+get-dotnetcore21:
+	kubeless function deploy get-dotnetcore21 --runtime dotnetcore2.1 --handler module.handler --from-file examples/helloget.cs
+
+get-dotnetcore-verify21:
+	kubectl rollout status deployment/get-dotnetcore21 && sleep 2
+	kubeless function call get-dotnetcore21 |egrep hello.world
+	kubeless function top --function get-dotnetcore21 --out yaml |egrep "Function does not expose metrics" 
+
+get-dotnetcore-clean21:
+    kubless function delete get-dotnetcore21
+
+get-dotnetcore-dependency21:
+	kubeless function deploy get-dotnetcore-dependency21 --runtime dotnetcore2.1 --handler module.handler --from-file examples/dependency-yaml.cs --dependencies examples/dependency-yaml.csproj
+
+get-dotnetcore-dependency-verify21:
+	kubectl rollout status deployment/get-dotnetcore-dependency21 && sleep 2
+	kubeless function call get-dotnetcore-dependency21 |egrep Name:\ Michael
+
+get-dotnetcore-dependency-clean21:
+    kubless function delete get-dotnetcore-dependency21
+
+post-dotnetcore21:
+	kubeless function deploy post-dotnetcore21 --runtime dotnetcore2.1 --handler module.handler --from-file examples/hellowithdata.cs
+
+post-dotnetcore-verify21:
+	kubectl rollout status deployment/post-dotnetcore21 && sleep 2
+	kubeless function call post-dotnetcore21 --data '{"it-s": "alive"}'|egrep "it.*alive"
+	
+post-dotnetcore-clean21:
+    kubless function delete post-dotnetcore21
+	
+get-dotnetcore-namespaced21:
+	kubeless function deploy get-dotnetcore-namespaced21 --runtime dotnetcore2.1 --handler module.handler --from-file examples/namespaced-helloget.cs
+
+get-dotnetcore-namespaced-verify21:
+	kubectl rollout status deployment/get-dotnetcore-namespaced21 && sleep 2
+	kubeless function call get-dotnetcore-namespaced21 |egrep hello.world
+	
+get-dotnetcore-namespaced-clean21:
+    kubless function delete get-dotnetcore-namespaced21
 
 # NET Core 2.0
 
@@ -42,10 +107,16 @@ get-dotnetcore-verify20:
 	kubectl rollout status deployment/get-dotnetcore20 && sleep 2
 	kubeless function call get-dotnetcore20 |egrep hello.world
 	kubeless function top --function get-dotnetcore20 --out yaml |egrep "Function does not expose metrics" 
-
+	
+get-dotnetcore-clean20:
+	kubeless function delete get-dotnetcore20
+	
 get-dotnetcore-dependency20:
 	kubeless function deploy get-dotnetcore-dependency20 --runtime dotnetcore2.0 --handler module.handler --from-file examples/dependency-yaml.cs --dependencies examples/dependency-yaml.csproj
 
 get-dotnetcore-dependency-verify20:
 	kubectl rollout status deployment/get-dotnetcore-dependency20 && sleep 2
 	kubeless function call get-dotnetcore-dependency20 |egrep Name:\ Michael
+	
+get-dotnetcore-dependency-clean20:
+	kubeless function delete get-dotnetcore-dependency20

--- a/stable/dotnetcore/Makefile
+++ b/stable/dotnetcore/Makefile
@@ -1,65 +1,65 @@
 # Testing jobs
 deploy: deploy22 deploy21 deploy20
 
-deploy22: get-dotnetcore get-dotnetcore-dependency post-dotnetcore get-dotnetcore-namespaced 
+deploy22: get-dotnetcore22 get-dotnetcore-dependency22 post-dotnetcore22 get-dotnetcore-namespaced22
 deploy21: get-dotnetcore21 get-dotnetcore-dependency21 post-dotnetcore21 get-dotnetcore-namespaced21  
 deploy20: get-dotnetcore20 get-dotnetcore-dependency20
 
 test: test22 test21 test20
 
-test22: get-dotnetcore-verify get-dotnetcore-dependency-verify post-dotnetcore-verify get-dotnetcore-namespaced-verify 
+test22: get-dotnetcore-verify22 get-dotnetcore-dependency-verify22 post-dotnetcore-verify22 get-dotnetcore-namespaced-verify22
 test21: get-dotnetcore-verify21 get-dotnetcore-dependency-verify21 post-dotnetcore-verify21 get-dotnetcore-namespaced-verify21 
 test20: get-dotnetcore-verify20 get-dotnetcore-dependency-verify20
 
 clean: clean22 clean21 clean20
 
-clean22: get-dotnetcore-clean get-dotnetcore-dependency-clean post-dotnetcore-clean get-dotnetcore-namespaced-clean
+clean22: get-dotnetcore-clean22 get-dotnetcore-dependency-clean22 post-dotnetcore-clean22 get-dotnetcore-namespaced-clean22
 clean21: get-dotnetcore-clean21 get-dotnetcore-dependency-clean21 post-dotnetcore-clean21 get-dotnetcore-namespaced-clean21
 clean20: get-dotnetcore-clean20 get-dotnetcore-dependency-clean20
 
 
 # .NET Core 2.2
 
-get-dotnetcore:
-	kubeless function deploy get-dotnetcore --runtime dotnetcore2.2 --handler module.handler --from-file examples/helloget.cs
+get-dotnetcore22:
+	kubeless function deploy get-dotnetcore22 --runtime dotnetcore2.2 --handler module.handler --from-file examples/helloget.cs
 
-get-dotnetcore-verify:
-	kubectl rollout status deployment/get-dotnetcore && sleep 2
-	kubeless function call get-dotnetcore |egrep hello.world
-	kubeless function top --function get-dotnetcore --out yaml |egrep "function: get-dotnetcore" 
+get-dotnetcore-verify22:
+	kubectl rollout status deployment/get-dotnetcore22 && sleep 4
+	kubeless function call get-dotnetcore22 |egrep hello.world
+	kubeless function top --function get-dotnetcore22 --out yaml |egrep "function: get-dotnetcore"
 
-get-dotnetcore-clean:
-	kubeless function delete get-dotnetcore
+get-dotnetcore-clean22:
+	kubeless function delete get-dotnetcore22
 	
-get-dotnetcore-dependency:
-	kubeless function deploy get-dotnetcore-dependency --runtime dotnetcore2.2 --handler module.handler --from-file examples/dependency-yaml.cs --dependencies examples/dependency-yaml.csproj
+get-dotnetcore-dependency22:
+	kubeless function deploy get-dotnetcore-dependency22 --runtime dotnetcore2.2 --handler module.handler --from-file examples/dependency-yaml.cs --dependencies examples/dependency-yaml.csproj
 
-get-dotnetcore-dependency-verify:
-	kubectl rollout status deployment/get-dotnetcore-dependency && sleep 2
-	kubeless function call get-dotnetcore-dependency |egrep Name:\ Michael
+get-dotnetcore-dependency-verify22:
+	kubectl rollout status deployment/get-dotnetcore-dependency22 && sleep 4
+	kubeless function call get-dotnetcore-dependency22 |egrep Name:\ Michael
 
-get-dotnetcore-dependency-clean:
-	kubeless function delete get-dotnetcore-dependency
+get-dotnetcore-dependency-clean22:
+	kubeless function delete get-dotnetcore-dependency22
 
-post-dotnetcore:
-	kubeless function deploy post-dotnetcore --runtime dotnetcore2.2 --handler module.handler --from-file examples/hellowithdata.cs
+post-dotnetcore22:
+	kubeless function deploy post-dotnetcore22 --runtime dotnetcore2.2 --handler module.handler --from-file examples/hellowithdata.cs
 
-post-dotnetcore-verify:
-	kubectl rollout status deployment/post-dotnetcore && sleep 2
-	kubeless function call post-dotnetcore --data '{"it-s": "alive"}'|egrep "it.*alive"
+post-dotnetcore-verify22:
+	kubectl rollout status deployment/post-dotnetcore22 && sleep 4
+	kubeless function call post-dotnetcore22 --data '{"it-s": "alive"}'|egrep "it.*alive"
 	
-post-dotnetcore-clean:
-	kubeless function delete post-dotnetcore
+post-dotnetcore-clean22:
+	kubeless function delete post-dotnetcore22
 
-get-dotnetcore-namespaced:
-	kubeless function deploy get-dotnetcore-namespaced --runtime dotnetcore2.2 --handler module.handler --from-file examples/namespaced-helloget.cs
+get-dotnetcore-namespaced22:
+	kubeless function deploy get-dotnetcore-namespaced22 --runtime dotnetcore2.2 --handler module.handler --from-file examples/namespaced-helloget.cs
 
-get-dotnetcore-namespaced-verify:
-	kubectl rollout status deployment/get-dotnetcore-namespaced && sleep 2
-	kubeless function call get-dotnetcore-namespaced |egrep hello.world
+get-dotnetcore-namespaced-verify22:
+	kubectl rollout status deployment/get-dotnetcore-namespaced22 && sleep 4
+	kubeless function call get-dotnetcore-namespaced22 |egrep hello.world
 
-get-dotnetcore-namespaced-clean:
-	kubeless function delete get-dotnetcore-namespaced
+get-dotnetcore-namespaced-clean22:
+	kubeless function delete get-dotnetcore-namespaced22
 
 # .NET Core 2.1
 
@@ -67,7 +67,7 @@ get-dotnetcore21:
 	kubeless function deploy get-dotnetcore21 --runtime dotnetcore2.1 --handler module.handler --from-file examples/helloget.cs
 
 get-dotnetcore-verify21:
-	kubectl rollout status deployment/get-dotnetcore21 && sleep 2
+	kubectl rollout status deployment/get-dotnetcore21 && sleep 4
 	kubeless function call get-dotnetcore21 |egrep hello.world
 	kubeless function top --function get-dotnetcore21 --out yaml |egrep "Function does not expose metrics" 
 
@@ -78,7 +78,7 @@ get-dotnetcore-dependency21:
 	kubeless function deploy get-dotnetcore-dependency21 --runtime dotnetcore2.1 --handler module.handler --from-file examples/dependency-yaml.cs --dependencies examples/dependency-yaml.csproj
 
 get-dotnetcore-dependency-verify21:
-	kubectl rollout status deployment/get-dotnetcore-dependency21 && sleep 2
+	kubectl rollout status deployment/get-dotnetcore-dependency21 && sleep 4
 	kubeless function call get-dotnetcore-dependency21 |egrep Name:\ Michael
 
 get-dotnetcore-dependency-clean21:
@@ -88,7 +88,7 @@ post-dotnetcore21:
 	kubeless function deploy post-dotnetcore21 --runtime dotnetcore2.1 --handler module.handler --from-file examples/hellowithdata.cs
 
 post-dotnetcore-verify21:
-	kubectl rollout status deployment/post-dotnetcore21 && sleep 2
+	kubectl rollout status deployment/post-dotnetcore21 && sleep 4
 	kubeless function call post-dotnetcore21 --data '{"it-s": "alive"}'|egrep "it.*alive"
 	
 post-dotnetcore-clean21:
@@ -98,7 +98,7 @@ get-dotnetcore-namespaced21:
 	kubeless function deploy get-dotnetcore-namespaced21 --runtime dotnetcore2.1 --handler module.handler --from-file examples/namespaced-helloget.cs
 
 get-dotnetcore-namespaced-verify21:
-	kubectl rollout status deployment/get-dotnetcore-namespaced21 && sleep 2
+	kubectl rollout status deployment/get-dotnetcore-namespaced21 && sleep 4
 	kubeless function call get-dotnetcore-namespaced21 |egrep hello.world
 	
 get-dotnetcore-namespaced-clean21:
@@ -110,7 +110,7 @@ get-dotnetcore20:
 	kubeless function deploy get-dotnetcore20 --runtime dotnetcore2.0 --handler module.handler --from-file examples/helloget.cs
 
 get-dotnetcore-verify20:
-	kubectl rollout status deployment/get-dotnetcore20 && sleep 2
+	kubectl rollout status deployment/get-dotnetcore20 && sleep 4
 	kubeless function call get-dotnetcore20 |egrep hello.world
 	kubeless function top --function get-dotnetcore20 --out yaml |egrep "Function does not expose metrics" 
 	
@@ -121,7 +121,7 @@ get-dotnetcore-dependency20:
 	kubeless function deploy get-dotnetcore-dependency20 --runtime dotnetcore2.0 --handler module.handler --from-file examples/dependency-yaml.cs --dependencies examples/dependency-yaml.csproj
 
 get-dotnetcore-dependency-verify20:
-	kubectl rollout status deployment/get-dotnetcore-dependency20 && sleep 2
+	kubectl rollout status deployment/get-dotnetcore-dependency20 && sleep 4
 	kubeless function call get-dotnetcore-dependency20 |egrep Name:\ Michael
 	
 get-dotnetcore-dependency-clean20:

--- a/stable/dotnetcore/Makefile
+++ b/stable/dotnetcore/Makefile
@@ -1,15 +1,21 @@
 # Testing jobs
-deploy: get-dotnetcore get-dotnetcore-dependency post-dotnetcore get-dotnetcore-namespaced 
-# get-dotnetcore21 get-dotnetcore-dependency21 post-dotnetcore21 get-dotnetcore-namespaced21 
-# get-dotnetcore20 get-dotnetcore-dependency20
+deploy: deploy22 deploy21 deploy20
 
-test: get-dotnetcore-verify get-dotnetcore-dependency-verify post-dotnetcore-verify get-dotnetcore-namespaced-verify 
-# get-dotnetcore-verify21 get-dotnetcore-dependency-verify21 post-dotnetcore-verify21 get-dotnetcore-namespaced-verify21 
-# get-dotnetcore-verify20 get-dotnetcore-dependency-verify20
+deploy22: get-dotnetcore get-dotnetcore-dependency post-dotnetcore get-dotnetcore-namespaced 
+deploy21: get-dotnetcore21 get-dotnetcore-dependency21 post-dotnetcore21 get-dotnetcore-namespaced21  
+deploy20: get-dotnetcore20 get-dotnetcore-dependency20
 
-clean: get-dotnetcore-clean get-dotnetcore-dependency-clean post-dotnetcore-clean get-dotnetcore-namespaced-clean
-# get-dotnetcore-verify21-clean get-dotnetcore-dependency-verify21-clean post-dotnetcore-verify21-clean get-dotnetcore-namespaced-verify21-clean 
-# get-dotnetcore-verify20-clean get-dotnetcore-dependency-verify20-clean
+test: test22 test21 test20
+
+test22: get-dotnetcore-verify get-dotnetcore-dependency-verify post-dotnetcore-verify get-dotnetcore-namespaced-verify 
+test21: get-dotnetcore-verify21 get-dotnetcore-dependency-verify21 post-dotnetcore-verify21 get-dotnetcore-namespaced-verify21 
+test20: get-dotnetcore-verify20 get-dotnetcore-dependency-verify20
+
+clean: clean22 clean21 clean20
+
+clean22: get-dotnetcore-clean get-dotnetcore-dependency-clean post-dotnetcore-clean get-dotnetcore-namespaced-clean
+clean21: get-dotnetcore-clean21 get-dotnetcore-dependency-clean21 post-dotnetcore-clean21 get-dotnetcore-namespaced-clean21
+clean20: get-dotnetcore-clean20 get-dotnetcore-dependency-clean20
 
 
 # .NET Core 2.2
@@ -20,11 +26,11 @@ get-dotnetcore:
 get-dotnetcore-verify:
 	kubectl rollout status deployment/get-dotnetcore && sleep 2
 	kubeless function call get-dotnetcore |egrep hello.world
-	kubeless function top --function get-dotnetcore --out yaml |egrep "Function does not expose metrics" 
+	kubeless function top --function get-dotnetcore --out yaml |egrep "function: get-dotnetcore" 
 
 get-dotnetcore-clean:
-    kubless function delete get-dotnetcore
-    
+	kubeless function delete get-dotnetcore
+	
 get-dotnetcore-dependency:
 	kubeless function deploy get-dotnetcore-dependency --runtime dotnetcore2.2 --handler module.handler --from-file examples/dependency-yaml.cs --dependencies examples/dependency-yaml.csproj
 
@@ -33,7 +39,7 @@ get-dotnetcore-dependency-verify:
 	kubeless function call get-dotnetcore-dependency |egrep Name:\ Michael
 
 get-dotnetcore-dependency-clean:
-    kubless function delete get-dotnetcore-dependency
+	kubeless function delete get-dotnetcore-dependency
 
 post-dotnetcore:
 	kubeless function deploy post-dotnetcore --runtime dotnetcore2.2 --handler module.handler --from-file examples/hellowithdata.cs
@@ -43,7 +49,7 @@ post-dotnetcore-verify:
 	kubeless function call post-dotnetcore --data '{"it-s": "alive"}'|egrep "it.*alive"
 	
 post-dotnetcore-clean:
-    kubless function delete post-dotnetcore
+	kubeless function delete post-dotnetcore
 
 get-dotnetcore-namespaced:
 	kubeless function deploy get-dotnetcore-namespaced --runtime dotnetcore2.2 --handler module.handler --from-file examples/namespaced-helloget.cs
@@ -53,7 +59,7 @@ get-dotnetcore-namespaced-verify:
 	kubeless function call get-dotnetcore-namespaced |egrep hello.world
 
 get-dotnetcore-namespaced-clean:
-    kubless function delete get-dotnetcore-namespaced
+	kubeless function delete get-dotnetcore-namespaced
 
 # .NET Core 2.1
 
@@ -66,7 +72,7 @@ get-dotnetcore-verify21:
 	kubeless function top --function get-dotnetcore21 --out yaml |egrep "Function does not expose metrics" 
 
 get-dotnetcore-clean21:
-    kubless function delete get-dotnetcore21
+	kubeless function delete get-dotnetcore21
 
 get-dotnetcore-dependency21:
 	kubeless function deploy get-dotnetcore-dependency21 --runtime dotnetcore2.1 --handler module.handler --from-file examples/dependency-yaml.cs --dependencies examples/dependency-yaml.csproj
@@ -76,7 +82,7 @@ get-dotnetcore-dependency-verify21:
 	kubeless function call get-dotnetcore-dependency21 |egrep Name:\ Michael
 
 get-dotnetcore-dependency-clean21:
-    kubless function delete get-dotnetcore-dependency21
+	kubeless function delete get-dotnetcore-dependency21
 
 post-dotnetcore21:
 	kubeless function deploy post-dotnetcore21 --runtime dotnetcore2.1 --handler module.handler --from-file examples/hellowithdata.cs
@@ -86,7 +92,7 @@ post-dotnetcore-verify21:
 	kubeless function call post-dotnetcore21 --data '{"it-s": "alive"}'|egrep "it.*alive"
 	
 post-dotnetcore-clean21:
-    kubless function delete post-dotnetcore21
+	kubeless function delete post-dotnetcore21
 	
 get-dotnetcore-namespaced21:
 	kubeless function deploy get-dotnetcore-namespaced21 --runtime dotnetcore2.1 --handler module.handler --from-file examples/namespaced-helloget.cs
@@ -96,7 +102,7 @@ get-dotnetcore-namespaced-verify21:
 	kubeless function call get-dotnetcore-namespaced21 |egrep hello.world
 	
 get-dotnetcore-namespaced-clean21:
-    kubless function delete get-dotnetcore-namespaced21
+	kubeless function delete get-dotnetcore-namespaced21
 
 # NET Core 2.0
 

--- a/stable/dotnetcore/Makefile
+++ b/stable/dotnetcore/Makefile
@@ -129,11 +129,12 @@ get-dotnetcore-dependency-clean20:
 	
 	
 # build docker
+# please set TARGET_REPOSITORY and RUNTIME_TAG_MODIFIER as env variables before using the docker build commands
 
-REPOSITORY		:= lennartquerter
+REPOSITORY		:= ${TARGET_REPOSITORY}
 RUNTIME_NAME	:= ${REPOSITORY}/kubless_runtime_dotnetcore22
 COMPILE_NAME	:= ${REPOSITORY}/kubless_compile_dotnetcore22
-TAG				:= $(shell git log -1 --pretty=%H)
+TAG				:= ${RUNTIME_TAG_MODIFIER}
 RUNTIME_IMG		:= ${RUNTIME_NAME}
 COMPILE_IMG		:= ${COMPILE_NAME}
 

--- a/stable/dotnetcore/OWNERS
+++ b/stable/dotnetcore/OWNERS
@@ -1,2 +1,1 @@
 - allantargino
-- lennartquerter

--- a/stable/dotnetcore/OWNERS
+++ b/stable/dotnetcore/OWNERS
@@ -1,1 +1,2 @@
 - allantargino
+- lennartquerter

--- a/stable/dotnetcore/dotnetcore.jsonnet
+++ b/stable/dotnetcore/dotnetcore.jsonnet
@@ -30,7 +30,22 @@
           DOTNETCORE_HOME: "$(KUBELESS_INSTALL_VOLUME)/packages",
         },
       }],
-    }
+    },
+    {
+      name: "dotnetcore2.2",
+      version: "2.2",
+      images: [{
+        phase: "compilation",
+        image: "",
+        command: "/app/compile-function.sh $KUBELESS_INSTALL_VOLUME"
+       }, {
+        phase: "runtime",
+        image: "",
+        env: {
+          DOTNETCORE_HOME: "$(KUBELESS_INSTALL_VOLUME)/packages",
+        },
+      }],
+    },
   ],
   depName: "project.csproj",
   fileNameSuffix: ".cs"

--- a/stable/dotnetcore/dotnetcore.jsonnet
+++ b/stable/dotnetcore/dotnetcore.jsonnet
@@ -36,11 +36,11 @@
       version: "2.2",
       images: [{
         phase: "compilation",
-        image: "lennartquerter/kubless_runtime_dotnetcore22-build:0.9",
+        image: "lennartquerter/kubless_compile_dotnetcore22:965ada1b76c571376bb5aaf28f90ca29edbcfff1",
         command: "/app/compile-function.sh $KUBELESS_INSTALL_VOLUME"
        }, {
         phase: "runtime",
-        image: "lennartquerter/kubless_runtime_dotnetcore22:0.9",
+        image: "lennartquerter/kubless_runtime_dotnetcore22:965ada1b76c571376bb5aaf28f90ca29edbcfff1",
         env: {
           DOTNETCORE_HOME: "$(KUBELESS_INSTALL_VOLUME)/packages",
         },

--- a/stable/dotnetcore/dotnetcore.jsonnet
+++ b/stable/dotnetcore/dotnetcore.jsonnet
@@ -36,11 +36,11 @@
       version: "2.2",
       images: [{
         phase: "compilation",
-        image: "lennartquerter/kubless_compile_dotnetcore22:965ada1b76c571376bb5aaf28f90ca29edbcfff1",
+        image: "lennartquerter/kubless_compile_dotnetcore22:4761f204190ad59807b9231e096cbcb3901226cd",
         command: "/app/compile-function.sh $KUBELESS_INSTALL_VOLUME"
        }, {
         phase: "runtime",
-        image: "lennartquerter/kubless_runtime_dotnetcore22:965ada1b76c571376bb5aaf28f90ca29edbcfff1",
+        image: "lennartquerter/kubless_runtime_dotnetcore22:4761f204190ad59807b9231e096cbcb3901226cd",
         env: {
           DOTNETCORE_HOME: "$(KUBELESS_INSTALL_VOLUME)/packages",
         },

--- a/stable/dotnetcore/dotnetcore.jsonnet
+++ b/stable/dotnetcore/dotnetcore.jsonnet
@@ -36,11 +36,11 @@
       version: "2.2",
       images: [{
         phase: "compilation",
-        image: "",
+        image: "lennartquerter/kubless_runtime_dotnetcore22-build:0.9",
         command: "/app/compile-function.sh $KUBELESS_INSTALL_VOLUME"
        }, {
         phase: "runtime",
-        image: "",
+        image: "lennartquerter/kubless_runtime_dotnetcore22:0.9",
         env: {
           DOTNETCORE_HOME: "$(KUBELESS_INSTALL_VOLUME)/packages",
         },

--- a/stable/dotnetcore/examples/err.cs
+++ b/stable/dotnetcore/examples/err.cs
@@ -1,0 +1,10 @@
+using System;
+using Kubeless.Functions;
+
+public class module
+{
+    public int handler(Event k8Event, Context k8Context)
+    {
+      throw new Exception("this function will always throw.");
+    }
+}

--- a/stable/dotnetcore/examples/err.csproj
+++ b/stable/dotnetcore/examples/err.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Kubeless.Functions" Version="0.1.1" />
+  </ItemGroup>
+
+</Project>

--- a/stable/dotnetcore/src/Kubeless.Core.Tests/Kubeless.Core.Tests.csproj
+++ b/stable/dotnetcore/src/Kubeless.Core.Tests/Kubeless.Core.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/stable/dotnetcore/src/Kubeless.Core.Tests/ParametersTests.cs
+++ b/stable/dotnetcore/src/Kubeless.Core.Tests/ParametersTests.cs
@@ -6,8 +6,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace Kubeless.Core.Tests

--- a/stable/dotnetcore/src/Kubeless.Core.Tests/ReferencesTests.cs
+++ b/stable/dotnetcore/src/Kubeless.Core.Tests/ReferencesTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Kubeless.Core.Tests
+﻿namespace Kubeless.Core.Tests
 {
     public class ReferencesTests
     {

--- a/stable/dotnetcore/src/Kubeless.Core.Tests/TimeoutTests.cs
+++ b/stable/dotnetcore/src/Kubeless.Core.Tests/TimeoutTests.cs
@@ -34,17 +34,17 @@ namespace Kubeless.Core.Tests
             Assert.Throws<OperationCanceledException>(timeoutAction);
         }
 
-        [InlineData("cs", "timeout", "module", "handler", 5, 5)]
-        [InlineData("cs", "timeout", "module", "handler", 5, 6)]
-        [InlineData("cs", "timeout", "module", "handler", 5, 7)]
-        [InlineData("cs", "timeout", "module", "handler", 5, 8)]
-        [InlineData("cs", "timeout", "module", "handler", 5, 9)]
-        [InlineData("cs", "timeout", "module", "handler", 5, 10)]
+        [InlineData("cs", "timeout", "module", "handler", 4999, 5)]
+        [InlineData("cs", "timeout", "module", "handler", 5000, 6)]
+        [InlineData("cs", "timeout", "module", "handler", 5000, 7)]
+        [InlineData("cs", "timeout", "module", "handler", 5000, 8)]
+        [InlineData("cs", "timeout", "module", "handler", 5000, 9)]
+        [InlineData("cs", "timeout", "module", "handler", 5000, 10)]
         [Theory]
         public void RunWithoutTimeout(string language, string functionFileName, string moduleName, string functionHandler, int durationTime, int timeoutSeconds)
         {
             // Arrange
-            int sleepTime = durationTime * 1000;
+            int sleepTime = durationTime;
             int timeout = timeoutSeconds * 1000;
             IInvoker invoker = InvokerFactory.GetFunctionInvoker(language, functionFileName, moduleName, functionHandler, timeout);
             Event @event = new Event(sleepTime);

--- a/stable/dotnetcore/src/Kubeless.Core.Tests/Utils/EnvironmentManager.cs
+++ b/stable/dotnetcore/src/Kubeless.Core.Tests/Utils/EnvironmentManager.cs
@@ -1,10 +1,8 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 
 namespace Kubeless.Core.Tests.Utils

--- a/stable/dotnetcore/src/Kubeless.Core.Tests/Utils/FunctionCompiler.cs
+++ b/stable/dotnetcore/src/Kubeless.Core.Tests/Utils/FunctionCompiler.cs
@@ -36,7 +36,7 @@ namespace Kubeless.Core.Tests.Utils
 
             if (process.ExitCode != 0 || result.ToLower().Contains("error"))
                 throw new Exception("Error during dotnet publish");
-        }
+            }
 
         public string Compile(string functionPath, string packagesSubPath)
         {

--- a/stable/dotnetcore/src/Kubeless.Core.Tests/Utils/FunctionCompiler.cs
+++ b/stable/dotnetcore/src/Kubeless.Core.Tests/Utils/FunctionCompiler.cs
@@ -36,7 +36,7 @@ namespace Kubeless.Core.Tests.Utils
 
             if (process.ExitCode != 0 || result.ToLower().Contains("error"))
                 throw new Exception("Error during dotnet publish");
-            }
+        }
 
         public string Compile(string functionPath, string packagesSubPath)
         {

--- a/stable/dotnetcore/src/Kubeless.Core.Tests/Utils/FunctionFactory.cs
+++ b/stable/dotnetcore/src/Kubeless.Core.Tests/Utils/FunctionFactory.cs
@@ -1,9 +1,7 @@
 ﻿using Kubeless.Core.Interfaces;
 using Kubeless.Core.Models;
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace Kubeless.Core.Tests.Utils
 {

--- a/stable/dotnetcore/src/Kubeless.Core.Tests/Utils/InvokerFactory.cs
+++ b/stable/dotnetcore/src/Kubeless.Core.Tests/Utils/InvokerFactory.cs
@@ -1,9 +1,6 @@
 ﻿using Kubeless.Core.Interfaces;
 using Kubeless.Core.Invokers;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace Kubeless.Core.Tests.Utils
 {

--- a/stable/dotnetcore/src/Kubeless.Core/Handlers/DefaultParameterHandler.cs
+++ b/stable/dotnetcore/src/Kubeless.Core/Handlers/DefaultParameterHandler.cs
@@ -3,10 +3,7 @@ using Kubeless.Functions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace Kubeless.Core.Handlers
 {

--- a/stable/dotnetcore/src/Kubeless.Core/Interfaces/IParameterHandler.cs
+++ b/stable/dotnetcore/src/Kubeless.Core/Interfaces/IParameterHandler.cs
@@ -1,8 +1,5 @@
 ﻿using Kubeless.Functions;
 using Microsoft.AspNetCore.Http;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Kubeless.Core.Interfaces
 {

--- a/stable/dotnetcore/src/Kubeless.Core/Kubeless.Core.csproj
+++ b/stable/dotnetcore/src/Kubeless.Core/Kubeless.Core.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/stable/dotnetcore/src/Kubeless.Core/Models/CompiledFunction.cs
+++ b/stable/dotnetcore/src/Kubeless.Core/Models/CompiledFunction.cs
@@ -1,9 +1,5 @@
 ﻿using Kubeless.Core.Interfaces;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Kubeless.Core.Models
 {

--- a/stable/dotnetcore/src/Kubeless.Core/Utils/CustomReferencesManager.cs
+++ b/stable/dotnetcore/src/Kubeless.Core/Utils/CustomReferencesManager.cs
@@ -1,6 +1,4 @@
-﻿using Kubeless.Core.Utils;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 
 namespace Kubeless.Core.Utils

--- a/stable/dotnetcore/src/Kubeless.Core/Utils/FilterExtensions.cs
+++ b/stable/dotnetcore/src/Kubeless.Core/Utils/FilterExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.IO;
 using System.Text.RegularExpressions;

--- a/stable/dotnetcore/src/Kubeless.Functions/Models/Context.cs
+++ b/stable/dotnetcore/src/Kubeless.Functions/Models/Context.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Kubeless.Functions
+﻿namespace Kubeless.Functions
 {
     public class Context
     {

--- a/stable/dotnetcore/src/Kubeless.WebAPI.Tests/HealthTests.cs
+++ b/stable/dotnetcore/src/Kubeless.WebAPI.Tests/HealthTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Kubeless.WebAPI.Tests
 {
+    [Collection("health-check")]
     public class HealthTests
     {
         [InlineData("cs", "helloget", "module", "handler")]

--- a/stable/dotnetcore/src/Kubeless.WebAPI.Tests/InvokeTests.cs
+++ b/stable/dotnetcore/src/Kubeless.WebAPI.Tests/InvokeTests.cs
@@ -1,14 +1,13 @@
 using Kubeless.Core.Tests.Utils;
 using Kubeless.WebAPI.Tests.Utils;
-using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
-using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Kubeless.WebAPI.Tests
 {
+    [Collection("health-check")]
     public class InvokeTests
     {
         [InlineData("GET", "cs", "helloget", "module", "handler")]

--- a/stable/dotnetcore/src/Kubeless.WebAPI.Tests/Kubeless.WebAPI.Tests.csproj
+++ b/stable/dotnetcore/src/Kubeless.WebAPI.Tests/Kubeless.WebAPI.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/stable/dotnetcore/src/Kubeless.WebAPI.Tests/MetricsTests.cs
+++ b/stable/dotnetcore/src/Kubeless.WebAPI.Tests/MetricsTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Net;
+using Kubeless.Core.Tests.Utils;
+using Kubeless.WebAPI.Tests.Utils;
+using Microsoft.AspNetCore.TestHost;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kubeless.WebAPI.Tests
+{
+    [Collection("metrics-test")]
+    public class MetricsTests
+    {
+        [InlineData("cs", "helloget", "module", "handler", HttpStatusCode.OK)]
+        [InlineData("cs", "hellowithdata", "module", "handler", HttpStatusCode.OK)]
+        [InlineData("cs", "dependency-yaml", "module", "handler", HttpStatusCode.OK)]
+        [InlineData("cs", "namespaced-helloget", "module", "handler", HttpStatusCode.OK)]
+        [InlineData("cs", "err", "module", "handler", HttpStatusCode.InternalServerError)]
+        [Theory]
+        public async Task PerformMetricsTest(string language, string functionFileName, string moduleName, string functionHandler, HttpStatusCode expectedResponse)
+        {
+            // Arrange
+            EnvironmentManager.SetVariables(moduleName, functionHandler, funcRuntime: "dotnetcore2.2");
+            ServerCreator.CompileFunction(language, functionFileName, moduleName, functionHandler);
+            TestServer server = ServerCreator.CreateServer();
+            HttpClient client = server.CreateClient();
+
+            var request = new HttpRequestMessage(new HttpMethod("GET"), "/");
+            var invokeResponse = await client.SendAsync(request);
+            Assert.Equal(expectedResponse, invokeResponse.StatusCode);
+
+            // Act
+            var response = await client.GetAsync("/metrics");
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            var responseBody = await response.Content.ReadAsStringAsync();
+            Assert.Contains("kubeless_calls_total", responseBody);
+            Assert.Contains($"status=\"{(int) expectedResponse}\"", responseBody);
+            Assert.Contains("function=\"handler\"", responseBody);
+            Assert.Contains("runtime=\"dotnetcore2.2\"", responseBody);
+            Assert.Contains("handler=\"module\"", responseBody);
+        }
+    }
+}

--- a/stable/dotnetcore/src/Kubeless.WebAPI.Tests/Utils/ServerCreator.cs
+++ b/stable/dotnetcore/src/Kubeless.WebAPI.Tests/Utils/ServerCreator.cs
@@ -2,9 +2,6 @@
 using Kubeless.Core.Tests.Utils;
 using Microsoft.AspNetCore.TestHost;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Kubeless.WebAPI.Tests.Utils
 {

--- a/stable/dotnetcore/src/Kubeless.WebAPI.Tests/Utils/ServerCreator.cs
+++ b/stable/dotnetcore/src/Kubeless.WebAPI.Tests/Utils/ServerCreator.cs
@@ -12,7 +12,7 @@ namespace Kubeless.WebAPI.Tests.Utils
 
         public static TestServer CreateServer()
         {
-            return new TestServer(Program.CreateWebHostBuilder());
+            return new TestServer(Program.CreateWebHostBuilder(null));
         }
 
         public static void CompileFunction(string language, string functionFileName, string moduleName, string functionHandler)

--- a/stable/dotnetcore/src/Kubeless.WebAPI/Kubeless.WebAPI.csproj
+++ b/stable/dotnetcore/src/Kubeless.WebAPI/Kubeless.WebAPI.csproj
@@ -1,11 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="prometheus-net.AspNetCore">
+      <Version>3.1.4</Version>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/stable/dotnetcore/src/Kubeless.WebAPI/Program.cs
+++ b/stable/dotnetcore/src/Kubeless.WebAPI/Program.cs
@@ -1,8 +1,10 @@
+using System;
+using System.Diagnostics;
 using Kubeless.WebAPI.Utils;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Prometheus;
 
 namespace Kubeless.WebAPI
 {
@@ -10,17 +12,28 @@ namespace Kubeless.WebAPI
     {
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            try
+            {
+                CreateWebHostBuilder(args)
+                    .Build()
+                    .Run();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                throw;
+            }
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(params string[] args)
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args)
         {
             var port = VariablesUtils.GetEnvVar("FUNC_PORT", "8080");
 
             return WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
                 .UseUrls($"http://*:{port}")
-                .Configure(app => app.UseMetricServer())
+                .ConfigureAppConfiguration((hostingContext, config) => { config.AddEnvironmentVariables(); })
                 .ConfigureLogging((hostingContext, logging) =>
                 {
                     logging.AddConsole(options => options.IncludeScopes = true);

--- a/stable/dotnetcore/src/Kubeless.WebAPI/Program.cs
+++ b/stable/dotnetcore/src/Kubeless.WebAPI/Program.cs
@@ -1,13 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Kubeless.WebAPI.Utils;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Prometheus;
 
 namespace Kubeless.WebAPI
 {
@@ -25,6 +20,7 @@ namespace Kubeless.WebAPI
             return WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
                 .UseUrls($"http://*:{port}")
+                .Configure(app => app.UseMetricServer())
                 .ConfigureLogging((hostingContext, logging) =>
                 {
                     logging.AddConsole(options => options.IncludeScopes = true);

--- a/stable/dotnetcore/src/Kubeless.WebAPI/Program.cs
+++ b/stable/dotnetcore/src/Kubeless.WebAPI/Program.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using Kubeless.WebAPI.Utils;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;

--- a/stable/dotnetcore/src/Kubeless.WebAPI/Startup.cs
+++ b/stable/dotnetcore/src/Kubeless.WebAPI/Startup.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Kubeless.Core.Interfaces;
 using Kubeless.WebAPI.Utils;
 using Kubeless.Core.Invokers;
-using System.IO;
 using Kubeless.Core.Handlers;
 
 namespace Kubeless.WebAPI

--- a/stable/dotnetcore/src/Kubeless.WebAPI/Utils/VariablesUtils.cs
+++ b/stable/dotnetcore/src/Kubeless.WebAPI/Utils/VariablesUtils.cs
@@ -1,8 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Kubeless.WebAPI.Utils
 {


### PR DESCRIPTION
This pull request includes:

- Adding new runtime of dotnetcore 2.2
- Adding a metrics endpoint on `/metrics` (prometheus) (for dotnet core 2.2 runtime)
- Added new test that throws an error
- updated makefile to test all 3 runtimes of dotnet (2.0, 2.1 and 2.2)
- cleanup of unused 'using' statements

fix #42 