### PR TITLE
gracefully shutdown express on SIGINT & SIGTERM in nodejs runtimes.

### DIFF
--- a/stable/nodejs/kubeless.js
+++ b/stable/nodejs/kubeless.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const fs = require('fs');
 const vm = require('vm');
 const path = require('path');
 const Module = require('module');
@@ -10,6 +9,7 @@ const client = require('prom-client');
 const express = require('express');
 const helper = require('./lib/helper');
 const morgan = require('morgan');
+const GracefulShutdownManager = require('@moebius/http-graceful-shutdown').GracefulShutdownManager;
 
 const bodySizeLimit = Number(process.env.REQ_MB_LIMIT || '1');
 
@@ -168,4 +168,12 @@ app.all('*', (req, res) => {
     }
 });
 
-app.listen(funcPort);
+const server = app.listen(funcPort);
+const shutdownManager = new GracefulShutdownManager(server);
+
+const handleShutdown = () => {
+    shutdownManager.terminate();
+}
+
+process.on('SIGINT', handleShutdown);
+process.on('SIGTERM', handleShutdown);

--- a/stable/nodejs/kubeless.js
+++ b/stable/nodejs/kubeless.js
@@ -9,7 +9,6 @@ const client = require('prom-client');
 const express = require('express');
 const helper = require('./lib/helper');
 const morgan = require('morgan');
-const GracefulShutdownManager = require('@moebius/http-graceful-shutdown').GracefulShutdownManager;
 
 const bodySizeLimit = Number(process.env.REQ_MB_LIMIT || '1');
 
@@ -169,11 +168,4 @@ app.all('*', (req, res) => {
 });
 
 const server = app.listen(funcPort);
-const shutdownManager = new GracefulShutdownManager(server);
-
-const handleShutdown = () => {
-    shutdownManager.terminate();
-}
-
-process.on('SIGINT', handleShutdown);
-process.on('SIGTERM', handleShutdown);
+helper.configureGracefulShutdown(server);

--- a/stable/nodejs/lib/helper.js
+++ b/stable/nodejs/lib/helper.js
@@ -49,9 +49,54 @@ function routeMetrics(expressApp, promClient) {
   });
 }
 
+function configureGracefulShutdown(server) {
+  let nextConnectionId = 0;
+  const connections = [];
+  let terminating = false;
+
+  server.on('connection', connection => {
+    const connectionId = nextConnectionId++;
+    connection.$$isIdle = true;
+    connections[connectionId] = connection;
+    connection.on('close', () => delete connections[connectionId]);
+  });
+  server.on('request', (request, response) => {
+    const connection = request.connection;
+    connection.$$isIdle = false;
+
+    response.on('finish', () => {
+      connection.$$isIdle = true;
+      if (terminating) {
+        connection.destroy();
+      }
+
+    });
+  });
+
+  const handleShutdown = () => {
+    console.log("Shutting down..");
+
+    terminating = true;
+    server.close(() => console.log("Server stopped"));
+
+    for (const connectionId in connections) {
+      if (connections.hasOwnProperty(connectionId)) {
+        const connection = connections[connectionId];
+        if (connection.$$isIdle) {
+          connection.destroy();
+        }
+      }
+    }
+  };
+
+  process.on('SIGINT', handleShutdown);
+  process.on('SIGTERM', handleShutdown);
+}
+
 module.exports = {
   readDependencies,
   prepareStatistics,
   routeLivenessProbe,
   routeMetrics,
+  configureGracefulShutdown
 };

--- a/stable/nodejs/lib/helper.js
+++ b/stable/nodejs/lib/helper.js
@@ -60,6 +60,7 @@ function configureGracefulShutdown(server) {
     connections[connectionId] = connection;
     connection.on('close', () => delete connections[connectionId]);
   });
+
   server.on('request', (request, response) => {
     const connection = request.connection;
     connection.$$isIdle = false;
@@ -69,7 +70,6 @@ function configureGracefulShutdown(server) {
       if (terminating) {
         connection.destroy();
       }
-
     });
   });
 

--- a/stable/nodejs/package.json
+++ b/stable/nodejs/package.json
@@ -9,7 +9,6 @@
   },
   "homepage": "https://github.com/serverless/serverless-kubeless#readme",
   "dependencies": {
-    "@moebius/http-graceful-shutdown": "^1.1.0",
     "body-parser": "^1.17.2",
     "express": "^4.15.3",
     "morgan": "^1.8.2",

--- a/stable/nodejs/package.json
+++ b/stable/nodejs/package.json
@@ -9,6 +9,7 @@
   },
   "homepage": "https://github.com/serverless/serverless-kubeless#readme",
   "dependencies": {
+    "@moebius/http-graceful-shutdown": "^1.1.0",
     "body-parser": "^1.17.2",
     "express": "^4.15.3",
     "morgan": "^1.8.2",


### PR DESCRIPTION
Performs a graceful shutdown of express when a SIGINT or SIGTERM signal is received.

ref: kubeless/kubeless#1107