### PR TITLE
Solve issue 48: Python runtime deadlocks when a large amount of data …

### DIFF
--- a/stable/python/kubeless.py
+++ b/stable/python/kubeless.py
@@ -5,9 +5,13 @@ import imp
 import datetime
 
 from multiprocessing import Process, Queue
-import queue
 import bottle
 import prometheus_client as prom
+
+try:
+    import queue
+except:
+    import Queue as queue
 
 mod = imp.load_source('function',
                       '/kubeless/%s.py' % os.getenv('MOD_NAME'))

--- a/stable/python/python.jsonnet
+++ b/stable/python/python.jsonnet
@@ -10,7 +10,7 @@
         command: "pip install --prefix=$KUBELESS_INSTALL_VOLUME -r $KUBELESS_DEPS_FILE"
       }, {
         phase: "runtime",
-        image: "kubeless/python@sha256:255b019e73e545782f29309609342b16b41a7a1e257be1bab912bd70f8afcd15",
+        image: "kubeless/python@sha256:ce8181c88ea093659d79e0f33b2be5dd3b8c75d25c0f465fdedf7dfc3a6a1e5a",
         env: {
           PYTHONPATH: "$(KUBELESS_INSTALL_VOLUME)/lib/python2.7/site-packages:$(KUBELESS_INSTALL_VOLUME)",
         },

--- a/stable/python/python.jsonnet
+++ b/stable/python/python.jsonnet
@@ -10,7 +10,7 @@
         command: "pip install --prefix=$KUBELESS_INSTALL_VOLUME -r $KUBELESS_DEPS_FILE"
       }, {
         phase: "runtime",
-        image: "kubeless/python@sha256:7630749ee027e873b24468fec066df6a7e7f3fd6a62695405189821b7114d1e1",
+        image: "kubeless/python@sha256:255b019e73e545782f29309609342b16b41a7a1e257be1bab912bd70f8afcd15",
         env: {
           PYTHONPATH: "$(KUBELESS_INSTALL_VOLUME)/lib/python2.7/site-packages:$(KUBELESS_INSTALL_VOLUME)",
         },
@@ -40,7 +40,7 @@
         command: "pip install --prefix=$KUBELESS_INSTALL_VOLUME -r $KUBELESS_DEPS_FILE"
       }, {
         phase: "runtime",
-        image: "kubeless/python@sha256:d85ce9e4d54f9db4b911c3d92f4acaef149ac7e9975823107a7118bc82d80e5c",
+        image: "kubeless/python@sha256:63dc8e71d6e6f39561121763c23640373ee00eecfa630db1c01edf247c2204d9",
         env: {
           PYTHONPATH: "$(KUBELESS_INSTALL_VOLUME)/lib/python3.6/site-packages:$(KUBELESS_INSTALL_VOLUME)",
         },
@@ -55,7 +55,7 @@
         command: "pip install --prefix=$KUBELESS_INSTALL_VOLUME -r $KUBELESS_DEPS_FILE"
       }, {
         phase: "runtime",
-        image: "kubeless/python@sha256:f65ebe571a8e657049ec75408df6f8538ffe49037418e45b611d07243612b1fd",
+        image: "kubeless/python@sha256:76a32b0f4e11f02cd9e51147f4c3fed870c1ee2c9463167e9ef0e6856de99794",
         env: {
           PYTHONPATH: "$(KUBELESS_INSTALL_VOLUME)/lib/python3.7/site-packages:$(KUBELESS_INSTALL_VOLUME)",
         },


### PR DESCRIPTION
…is returned

The current Python runtime for Kubeless will deadlock when more data than the
OS pipe can handle is pushed to the queue.  The server blocks while the process
is alive and only then attempts to get the response from the queue.  However,
the process stays alive because it cannot push more data to the queue unless it
is read from.

This update instead blocks on reading from the queue and receives data as it is
pushed.

fixes #48 