### PR TITLE
Simplify exception handling

### DIFF
--- a/stable/dotnetcore/src/Kubeless.Core/Invokers/CompiledFunctionInvoker.cs
+++ b/stable/dotnetcore/src/Kubeless.Core/Invokers/CompiledFunctionInvoker.cs
@@ -44,15 +44,12 @@ namespace Kubeless.Core.Invokers
         {
             try {
                 return AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
-            } catch (FileLoadException exc) {
+            } catch (FileLoadException exc) when (exc.Message.Contains("Assembly with same name is already loaded")) {
                 // We need to check the exception message because 
                 // LoadFromAssemblyPath does not throw a specialized Exception 
                 // when an Assembly has already been loaded
-                if (exc.Message.Contains("Assembly with same name is already loaded")) {
-                    var assemblyName = AssemblyName.GetAssemblyName(path).Name;
-                    return AssemblyLoadContext.Default.Assemblies.SingleOrDefault(assembly => assembly.GetName().Name == assemblyName);
-                }
-                throw exc;
+                var assemblyName = AssemblyName.GetAssemblyName(path).Name;
+                return AssemblyLoadContext.Default.Assemblies.SingleOrDefault(assembly => assembly.GetName().Name == assemblyName);
             }
         }
 


### PR DESCRIPTION
This simplifies the exception handling on CompiledFunctionInvoker by using C#'s [exception filters](https://thomaslevesque.com/2015/06/21/exception-filters-in-c-6/).