### PR TITLE
.NET Core: support for functions with native dependencies

### DIFF
--- a/stable/dotnetcore/Dockerfile.3.1
+++ b/stable/dotnetcore/Dockerfile.3.1
@@ -19,4 +19,8 @@ COPY --from=build-env /app/Kubeless.WebAPI/out .
 # Kubeless.Functions reference
 COPY --from=build-env /app/Kubeless.WebAPI/out/Kubeless.Functions.dll /usr/share/dotnet/store/x64/netcoreapp2.0/.
 
-ENTRYPOINT ["dotnet", "Kubeless.WebAPI.dll"]
+RUN chown 1000 /app
+COPY ./run-webapi.sh ./
+RUN chmod +x ./run-webapi.sh
+
+ENTRYPOINT ["/app/run-webapi.sh"]

--- a/stable/dotnetcore/Kubeless.sln
+++ b/stable/dotnetcore/Kubeless.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kubeless.WebAPI.Tests", "sr
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Functions", "Functions", "{34726F86-409F-4426-9451-BBCF7E715292}"
 	ProjectSection(SolutionItems) = preProject
+		examples\native-deps\native-deps.cs = examples\native-deps\native-deps.cs
+		examples\native-deps\native-deps.csproj = examples\native-deps\native-deps.csproj
 		examples\dependency-yaml\dependency-yaml.cs = examples\dependency-yaml\dependency-yaml.cs
 		examples\dependency-yaml\dependency-yaml.csproj = examples\dependency-yaml\dependency-yaml.csproj
 		examples\fibonacci\fibonacci.cs = examples\fibonacci\fibonacci.cs

--- a/stable/dotnetcore/Kubeless.sln
+++ b/stable/dotnetcore/Kubeless.sln
@@ -31,6 +31,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Functions", "Functions", "{
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docker", "Docker", "{CCBE6752-398A-4934-B276-9557032BF32E}"
 	ProjectSection(SolutionItems) = preProject
+		run-webapi.sh = run-webapi.sh
 		compile-function.sh = compile-function.sh
 		Dockerfile = Dockerfile
 		Dockerfile.init = Dockerfile.init

--- a/stable/dotnetcore/Makefile
+++ b/stable/dotnetcore/Makefile
@@ -1,26 +1,36 @@
 # Testing jobs
 deploy: deploy31 deploy22 deploy21 deploy20
 
-deploy31: get-dotnetcore31 get-dotnetcore-dependency31 post-dotnetcore31
+deploy31: get-dotnetcore-native-deps31 get-dotnetcore31 get-dotnetcore-dependency31 post-dotnetcore31
 deploy22: get-dotnetcore22 get-dotnetcore-dependency22 post-dotnetcore22 get-dotnetcore-namespaced22
 deploy21: get-dotnetcore21 get-dotnetcore-dependency21 post-dotnetcore21 get-dotnetcore-namespaced21  
 deploy20: get-dotnetcore20 get-dotnetcore-dependency20
 
 test: test31 test22 test21 test20
 
-test31: get-dotnetcore-verify31 get-dotnetcore-dependency-verify31 post-dotnetcore-verify31
+test31: get-dotnetcore-native-deps-verify31 get-dotnetcore-verify31 get-dotnetcore-dependency-verify31 post-dotnetcore-verify31
 test22: get-dotnetcore-verify22 get-dotnetcore-dependency-verify22 post-dotnetcore-verify22 get-dotnetcore-namespaced-verify22
 test21: get-dotnetcore-verify21 get-dotnetcore-dependency-verify21 post-dotnetcore-verify21 get-dotnetcore-namespaced-verify21 
 test20: get-dotnetcore-verify20 get-dotnetcore-dependency-verify20
 
 clean: clean31 clean22 clean21 clean20
 
-clean31: get-dotnetcore-clean31 get-dotnetcore-dependency-clean31 post-dotnetcore-clean31
+clean31: get-dotnetcore-native-deps-clean31 get-dotnetcore-clean31 get-dotnetcore-dependency-clean31 post-dotnetcore-clean31
 clean22: get-dotnetcore-clean22 get-dotnetcore-dependency-clean22 post-dotnetcore-clean22 get-dotnetcore-namespaced-clean22
 clean21: get-dotnetcore-clean21 get-dotnetcore-dependency-clean21 post-dotnetcore-clean21 get-dotnetcore-namespaced-clean21
 clean20: get-dotnetcore-clean20 get-dotnetcore-dependency-clean20
 
 # .NET Core 3.1
+
+get-dotnetcore-native-deps31:
+	kubeless function deploy get-dotnetcore-native-deps31 --runtime dotnetcore3.1 --handler module.handler --from-file examples/native-deps/native-deps.cs --dependencies examples/native-deps/native-deps.csproj --env ASSEMBLY_NAME=native-deps
+
+get-dotnetcore-native-deps-verify31:
+	kubectl rollout status deployment/get-dotnetcore-native-deps31 && sleep 10
+	kubeless function call get-dotnetcore-native-deps31 |egrep "Okay native-deps"
+
+get-dotnetcore-native-deps-clean31:
+	kubeless function delete get-dotnetcore-native-deps31
 
 get-dotnetcore31:
 	kubeless function deploy get-dotnetcore31 --runtime dotnetcore3.1 --handler module.handler --from-file examples/helloget/helloget.cs

--- a/stable/dotnetcore/dotnetcore.jsonnet
+++ b/stable/dotnetcore/dotnetcore.jsonnet
@@ -55,7 +55,7 @@
         command: "/app/compile-function.sh $KUBELESS_INSTALL_VOLUME"
        }, {
         phase: "runtime",
-        image: "lorenzoangelini3/kubeless-runtime-dotnetcore31@sha256:337b964b69f86bf56add04861055aa67c2a661c0943f952ed97363b7cccdaa4b",
+        image: "lorenzoangelini3/kubeless-runtime-dotnetcore31@sha256:ccdff9e6428f17d9f263fb49619121dde1f06f364d0815368348f9dca4a35c67",
         env: {
           DOTNETCORE_HOME: "$(KUBELESS_INSTALL_VOLUME)/packages",
         },

--- a/stable/dotnetcore/dotnetcore.jsonnet
+++ b/stable/dotnetcore/dotnetcore.jsonnet
@@ -55,7 +55,7 @@
         command: "/app/compile-function.sh $KUBELESS_INSTALL_VOLUME"
        }, {
         phase: "runtime",
-        image: "lorenzoangelini3/kubeless-runtime-dotnetcore31@sha256:ccdff9e6428f17d9f263fb49619121dde1f06f364d0815368348f9dca4a35c67",
+        image: "lorenzoangelini3/kubeless-runtime-dotnetcore31@sha256:4a2d94bd6da4aee612a2009d863beb554c43e61199d8d3fc4bf2d28b5673940b",
         env: {
           DOTNETCORE_HOME: "$(KUBELESS_INSTALL_VOLUME)/packages",
         },

--- a/stable/dotnetcore/examples/native-deps/native-deps.cs
+++ b/stable/dotnetcore/examples/native-deps/native-deps.cs
@@ -1,0 +1,22 @@
+using System;
+using Kubeless.Functions;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Data.SqlClient;
+
+public class module
+{
+    const string FAKE_CONN_STRING = "Server=FAKEHOST;Database=FAKEDB;User Id=sa;Password=FAKEPWD;Trusted_Connection=False;MultipleActiveResultSets=True;Persist Security Info=True;Connect Timeout=1";
+    public Task<object> handler(Event k8Event, Context k8Context)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<DbContext>();
+        var options = optionsBuilder.UseSqlServer(FAKE_CONN_STRING).Options;
+        var dbCtx = new DbContext(options);
+        try {
+            var canConnect = dbCtx.Database.CanConnect();
+        } catch (SqlException exc) {
+            // It's all right, FAKEHOST does not exist :)
+        }
+        return Task.FromResult<object>("Okay native-deps");
+    }
+}

--- a/stable/dotnetcore/examples/native-deps/native-deps.csproj
+++ b/stable/dotnetcore/examples/native-deps/native-deps.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp31</TargetFramework>
+    <AssemblyName>native-deps</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Kubeless.Functions" Version="0.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.2" />
+  </ItemGroup>
+
+</Project>

--- a/stable/dotnetcore/run-webapi.sh
+++ b/stable/dotnetcore/run-webapi.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
+# If ASSEMBLY_NAME is not set, detect automatically from csproj filename
+export ASSEMBLY_NAME="${ASSEMBLY_NAME:=$(basename /kubeless/*.csproj .csproj)}"
+
 cp /kubeless/publish/*.dll /app
 dotnet --additional-deps $KUBELESS_INSTALL_VOLUME/publish/*.deps.json --additionalprobingpath $KUBELESS_INSTALL_VOLUME/packages /app/Kubeless.WebAPI.dll

--- a/stable/dotnetcore/run-webapi.sh
+++ b/stable/dotnetcore/run-webapi.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cp /kubeless/publish/*.dll /app
+dotnet --additional-deps $KUBELESS_INSTALL_VOLUME/publish/*.deps.json --additionalprobingpath $KUBELESS_INSTALL_VOLUME/packages /app/Kubeless.WebAPI.dll

--- a/stable/dotnetcore/src/Kubeless.Core.Tests/Utils/FunctionCompiler.cs
+++ b/stable/dotnetcore/src/Kubeless.Core.Tests/Utils/FunctionCompiler.cs
@@ -5,19 +5,15 @@ using System.IO;
 namespace Kubeless.Core.Tests.Utils
 {
     /// <summary>
-    /// Simulates dependency restore executed in init container by Kubeless.
+    /// Simulates function source publish executed in init container by Kubeless.
     /// </summary>
     public static class FunctionCompiler
     {
         public static void PublishTestFunction(string language, string functionName)
         {
             var workingDirectory = Directory.GetCurrentDirectory();
-
             var projPath = Path.Combine(workingDirectory, functionName, $"{functionName}.{language}proj");
-            var publishPath = Path.Combine(workingDirectory, functionName, $"{functionName}-publish");
-            Publish(projPath, publishPath);
-
-            Environment.SetEnvironmentVariable("PUBLISH_PATH", Path.Combine(workingDirectory, functionName, $"{functionName}-publish"));
+            Publish(projPath, workingDirectory);
             Environment.SetEnvironmentVariable("ASSEMBLY_NAME", functionName);
         }
 

--- a/stable/dotnetcore/src/Kubeless.Core.Tests/Utils/InvokerFactory.cs
+++ b/stable/dotnetcore/src/Kubeless.Core.Tests/Utils/InvokerFactory.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using Kubeless.Core.Interfaces;
+﻿using Kubeless.Core.Interfaces;
 using Kubeless.Core.Invokers;
 using Kubeless.Core.Models;
-using System.IO;
 
 namespace Kubeless.Core.Tests.Utils
 {
@@ -13,10 +11,9 @@ namespace Kubeless.Core.Tests.Utils
             int timeout = 180000)
         {
             FunctionCompiler.PublishTestFunction(language, functionName);
-            var publishPath = Environment.GetEnvironmentVariable("PUBLISH_PATH");
 
-            var function = new CompiledFunction(moduleName, functionHandler, publishPath, functionName);
-            var invoker = new CompiledFunctionInvoker(function, timeout, publishPath);
+            var function = new CompiledFunction(moduleName, functionHandler, functionName);
+            var invoker = new CompiledFunctionInvoker(function, timeout);
 
             return invoker;
         }

--- a/stable/dotnetcore/src/Kubeless.Core/Interfaces/IFunction.cs
+++ b/stable/dotnetcore/src/Kubeless.Core/Interfaces/IFunction.cs
@@ -4,6 +4,6 @@
     {
         string ModuleName { get; }
         string FunctionHandler { get; }
-        string FunctionFile { get; }
+        string AssemblyName { get; }
     }
 }

--- a/stable/dotnetcore/src/Kubeless.Core/Invokers/CompiledFunctionInvoker.cs
+++ b/stable/dotnetcore/src/Kubeless.Core/Invokers/CompiledFunctionInvoker.cs
@@ -16,28 +16,19 @@ namespace Kubeless.Core.Invokers
         private readonly dynamic _moduleInstance;
         private readonly int _functionTimeout;
 
-        public CompiledFunctionInvoker(IFunction function, int functionTimeout, string publishPath)
+        public CompiledFunctionInvoker(IFunction function, int functionTimeout)
         {
             Function = function;
             _functionTimeout = functionTimeout;
 
-            var functionAssembly = LoadAssembly(function.FunctionFile);
-
-            LoadDependencies(publishPath);
+            var assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var functionAssemblyPath = Path.Combine(assemblyFolder, $"{function.AssemblyName}.dll");
+            var functionAssembly = LoadAssembly(functionAssemblyPath);
 
             var moduleType = functionAssembly.GetType(function.ModuleName);
             _moduleInstance = Activator.CreateInstance(moduleType);
 
             _methodInfo = moduleType.GetMethod(function.FunctionHandler);
-        }
-
-        private void LoadDependencies(string publishPath)
-        {
-            var dependencies = Directory.GetFiles(publishPath, "*.dll");
-            foreach (var path in dependencies) {
-                var dllName = Path.GetFileName(path);
-                LoadAssembly(path);
-            }
         }
 
         private Assembly LoadAssembly(string path)

--- a/stable/dotnetcore/src/Kubeless.Core/Models/CompiledFunction.cs
+++ b/stable/dotnetcore/src/Kubeless.Core/Models/CompiledFunction.cs
@@ -7,13 +7,13 @@ namespace Kubeless.Core.Models
     {
         public string ModuleName { get; }
         public string FunctionHandler { get; }
-        public string FunctionFile { get; }
+        public string AssemblyName { get; }
 
-        public CompiledFunction(string moduleName, string functionHandler, string publishPath, string assemblyName)
+        public CompiledFunction(string moduleName, string functionHandler, string assemblyName)
         {
             ModuleName = moduleName;
             FunctionHandler = functionHandler;
-            FunctionFile = Path.Combine(publishPath, $"{assemblyName}.dll");
+            AssemblyName = assemblyName;
         }
     }
 }

--- a/stable/dotnetcore/src/Kubeless.WebAPI.Tests/Utils/KubelessWebApplicationFactory.cs
+++ b/stable/dotnetcore/src/Kubeless.WebAPI.Tests/Utils/KubelessWebApplicationFactory.cs
@@ -25,9 +25,9 @@ namespace Kubeless.WebAPI.Tests.Utils
                 services.AddTransient<IInvoker>(provider => {
                     Func<string, string> config = s => Environment.GetEnvironmentVariable(s);
 
-                    var function = new CompiledFunction(config("MOD_NAME"), config("FUNC_HANDLER"), config("PUBLISH_PATH"), config("ASSEMBLY_NAME"));
+                    var function = new CompiledFunction(config("MOD_NAME"), config("FUNC_HANDLER"), config("ASSEMBLY_NAME"));
                     var timeoutMs = int.Parse(config("FUNC_TIMEOUT")) * 1000;
-                    return new CompiledFunctionInvoker(function, timeoutMs, config("PUBLISH_PATH"));
+                    return new CompiledFunctionInvoker(function, timeoutMs);
                 });
             });
         }

--- a/stable/dotnetcore/src/Kubeless.WebAPI/Startup.cs
+++ b/stable/dotnetcore/src/Kubeless.WebAPI/Startup.cs
@@ -27,7 +27,7 @@ namespace Kubeless.WebAPI
             var function = FunctionFactory.GetFunction(Configuration);
             var timeout = FunctionFactory.GetFunctionTimeout(Configuration);
 
-            services.AddTransient<IInvoker>(_ => new CompiledFunctionInvoker(function, timeout, FunctionFactory.GetFunctionPublishPath()));
+            services.AddTransient<IInvoker>(_ => new CompiledFunctionInvoker(function, timeout));
             services.AddSingleton<IParameterHandler>(new DefaultParameterHandler(Configuration));
         }
 

--- a/stable/dotnetcore/src/Kubeless.WebAPI/Utils/FunctionFactory.cs
+++ b/stable/dotnetcore/src/Kubeless.WebAPI/Utils/FunctionFactory.cs
@@ -6,7 +6,6 @@ namespace Kubeless.WebAPI.Utils
 {
     public class FunctionFactory
     {
-        private static readonly string PUBLISH_PATH = VariablesUtils.GetEnvVar("PUBLISH_PATH", "/kubeless/publish/");
         private static readonly string ASSEMBLY_NAME = VariablesUtils.GetEnvVar("ASSEMBLY_NAME", "project");
 
         public static IFunction GetFunction(IConfiguration configuration)
@@ -14,7 +13,7 @@ namespace Kubeless.WebAPI.Utils
             var moduleName = configuration.GetNotNullConfiguration("MOD_NAME");
             var functionHandler = configuration.GetNotNullConfiguration("FUNC_HANDLER");
 
-            return new CompiledFunction(moduleName, functionHandler, PUBLISH_PATH, ASSEMBLY_NAME);
+            return new CompiledFunction(moduleName, functionHandler, ASSEMBLY_NAME);
         }
 
         public static int GetFunctionTimeout(IConfiguration configuration)
@@ -23,11 +22,6 @@ namespace Kubeless.WebAPI.Utils
             var milisecondsInSecond = 1000;
 
             return int.Parse(timeoutSeconds) * milisecondsInSecond;
-        }
-
-        public static string GetFunctionPublishPath()
-        {
-            return PUBLISH_PATH;
         }
     }
 }


### PR DESCRIPTION
Hello,
if I deploy a function with Microsoft.EntityFrameworkCore.SqlServer dependency, the .NET Core Kubeless runtime (both the 2.x and the 3.1 runtimes) will throw errors when it tries to connect to the database.

I think the issue is related to CompiledFunctionInvoker that doesn't load correctly native dependencies (in the described scenario Microsoft.Data.SqlClient required for Microsoft.EntityFrameworkCore.SqlServer).

With this PR I heavily changed the function dependencies loading system.

In the current runtimes (2.x and 3.1) we manually load each function dependency with a call to "AssemblyLoadContext.Default.LoadFromAssemblyPath(path)" (3.1) or "Assembly.Load(assemblycontent)" (2.x).

In the code of this PR we launch the Kubeless runtime with the "--additional-deps" and "--additionalprobingpath" options to make .NET Core include dependencies of the function project.

In this way we no more need to manually load function dependencies, we only manually load the assembly that contains the function code and all its dependencies will be loaded automatically by .NET Core.

I added a new test job that deploys a function with a native dependency.

I hope this PR could be merged to the official repo, let me know if you have any questions, comments or suggestions :)

Thank you very much for your work,
Lorenzo
