### PR TITLE
Fixed the issue of metrics for golang runtime

### DIFF
--- a/stable/golang/Dockerfile.1.11.init
+++ b/stable/golang/Dockerfile.1.11.init
@@ -8,6 +8,8 @@ RUN mkdir -p /go/pkg/dep
 # Prepare function environment
 RUN ln -s /kubeless $GOPATH/src/kubeless 
 ADD /compile-function.sh /
+WORKDIR /	
+RUN chmod +x compile-function.sh	
 
 # Install controller
 RUN mkdir -p $GOPATH/src/github.com/kubeless/kubeless/pkg/functions

--- a/stable/golang/Dockerfile.1.11.init
+++ b/stable/golang/Dockerfile.1.11.init
@@ -8,8 +8,7 @@ RUN mkdir -p /go/pkg/dep
 # Prepare function environment
 RUN ln -s /kubeless $GOPATH/src/kubeless 
 ADD /compile-function.sh /
-WORKDIR /	
-RUN chmod +x compile-function.sh	
+RUN chmod +x /compile-function.sh	
 
 # Install controller
 RUN mkdir -p $GOPATH/src/github.com/kubeless/kubeless/pkg/functions

--- a/stable/golang/Dockerfile.1.12.init
+++ b/stable/golang/Dockerfile.1.12.init
@@ -8,6 +8,8 @@ RUN mkdir -p /go/pkg/dep
 # Prepare function environment
 RUN ln -s /kubeless $GOPATH/src/kubeless 
 ADD /compile-function.sh /
+WORKDIR /	
+RUN chmod +x compile-function.sh	
 
 # Install controller
 RUN mkdir -p $GOPATH/src/github.com/kubeless/kubeless/pkg/functions

--- a/stable/golang/Dockerfile.1.12.init
+++ b/stable/golang/Dockerfile.1.12.init
@@ -8,8 +8,7 @@ RUN mkdir -p /go/pkg/dep
 # Prepare function environment
 RUN ln -s /kubeless $GOPATH/src/kubeless 
 ADD /compile-function.sh /
-WORKDIR /	
-RUN chmod +x compile-function.sh	
+RUN chmod +x /compile-function.sh	
 
 # Install controller
 RUN mkdir -p $GOPATH/src/github.com/kubeless/kubeless/pkg/functions

--- a/stable/golang/Dockerfile.init
+++ b/stable/golang/Dockerfile.init
@@ -8,6 +8,8 @@ RUN mkdir -p /go/pkg/dep
 # Prepare function environment
 RUN ln -s /kubeless $GOPATH/src/kubeless 
 ADD /compile-function.sh /
+WORKDIR /	
+RUN chmod +x compile-function.sh	
 
 # Install controller
 RUN mkdir -p $GOPATH/src/github.com/kubeless/kubeless/pkg/functions

--- a/stable/golang/Dockerfile.init
+++ b/stable/golang/Dockerfile.init
@@ -8,8 +8,7 @@ RUN mkdir -p /go/pkg/dep
 # Prepare function environment
 RUN ln -s /kubeless $GOPATH/src/kubeless 
 ADD /compile-function.sh /
-WORKDIR /	
-RUN chmod +x compile-function.sh	
+RUN chmod +x /compile-function.sh	
 
 # Install controller
 RUN mkdir -p $GOPATH/src/github.com/kubeless/kubeless/pkg/functions

--- a/stable/golang/golang.jsonnet
+++ b/stable/golang/golang.jsonnet
@@ -6,15 +6,15 @@
       version: "1.10",
       images: [{
         phase: "compilation",
-        image: "kubeless/go-init@sha256:cee10536fc4dca78928f21c85462ff75ec79e3425403f9c8b233f43df074d256",
+        image: "kubeless/go-init@sha256:163f46d781301490436db334ed34845a08f9b5c39746932a5d93b4c11c4ad43b",
         command: "/compile-function.sh"
        }, {
         phase: "installation",
-        image: "kubeless/go-init@sha256:cee10536fc4dca78928f21c85462ff75ec79e3425403f9c8b233f43df074d256",
+        image: "kubeless/go-init@sha256:163f46d781301490436db334ed34845a08f9b5c39746932a5d93b4c11c4ad43b",
         command: "cd $GOPATH/src/kubeless && dep ensure > /dev/termination-log 2>&1"
        }, {
         phase: "runtime",
-        image: "kubeless/go@sha256:27bf0dfd1633e50c02f0fe8aed079571a4001126206aaa89ee024c26b94999fe"
+        image: "kubeless/go@sha256:d2c5cfd3b7b31276d02ca22ddc7961aebe6050add4482b695ae3a686c76bad35"
       }],
     },
     {
@@ -22,21 +22,21 @@
       version: "1.11",
       images: [{
         phase: "compilation",
-        image: "kubeless/go-init@sha256:b364af8edb70a0d92ef992b667f56a5df159181310ec2d5e33a07da15ca88902",
+        image: "kubeless/go-init@sha256:e3592e7605608b620bc8f313c9b1e0e3ae4795bab8bdf1c01d53dd992ef316cd",
         command: "/compile-function.sh",
         env: {
           GOCACHE: "$(KUBELESS_INSTALL_VOLUME)/.cache",
         },
        }, {
         phase: "installation",
-        image: "kubeless/go-init@sha256:b364af8edb70a0d92ef992b667f56a5df159181310ec2d5e33a07da15ca88902",
+        image: "kubeless/go-init@sha256:e3592e7605608b620bc8f313c9b1e0e3ae4795bab8bdf1c01d53dd992ef316cd",
         command: "cd $GOPATH/src/kubeless && dep ensure > /dev/termination-log 2>&1",
         env: {
           GOCACHE: "$(KUBELESS_INSTALL_VOLUME)/.cache",
         },
        }, {
         phase: "runtime",
-        image: "kubeless/go@sha256:27bf0dfd1633e50c02f0fe8aed079571a4001126206aaa89ee024c26b94999fe"
+        image: "kubeless/go@sha256:d2c5cfd3b7b31276d02ca22ddc7961aebe6050add4482b695ae3a686c76bad35"
       }],
     },
     {
@@ -44,21 +44,21 @@
       version: "1.12",
       images: [{
         phase: "compilation",
-        image: "kubeless/go-init@sha256:67b9d5cbd93500dfe8f15de8b7846069180a2a50d2fdb63b42330de32cfe17ab",
+        image: "kubeless/go-init@sha256:a669748f121755966e884455c9b6a978f1b92dca85f5bf53c1cf0aff76acb6b6",
         command: "/compile-function.sh",
         env: {
           GOCACHE: "$(KUBELESS_INSTALL_VOLUME)/.cache",
         },
        }, {
         phase: "installation",
-        image: "kubeless/go-init@sha256:67b9d5cbd93500dfe8f15de8b7846069180a2a50d2fdb63b42330de32cfe17ab",
+        image: "kubeless/go-init@sha256:a669748f121755966e884455c9b6a978f1b92dca85f5bf53c1cf0aff76acb6b6",
         command: "cd $GOPATH/src/kubeless && dep ensure > /dev/termination-log 2>&1",
         env: {
           GOCACHE: "$(KUBELESS_INSTALL_VOLUME)/.cache",
         },
        }, {
         phase: "runtime",
-        image: "kubeless/go@sha256:27bf0dfd1633e50c02f0fe8aed079571a4001126206aaa89ee024c26b94999fe"
+        image: "kubeless/go@sha256:d2c5cfd3b7b31276d02ca22ddc7961aebe6050add4482b695ae3a686c76bad35"
       }],
     },
   ],

--- a/stable/golang/kubeless.tpl.go
+++ b/stable/golang/kubeless.tpl.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+
 	"kubeless"
 
 	proxyUtils "github.com/kubeless/kubeless/pkg/function-proxy/utils"

--- a/stable/golang/kubeless.tpl.go
+++ b/stable/golang/kubeless.tpl.go
@@ -21,12 +21,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-
 	"kubeless"
 
 	proxyUtils "github.com/kubeless/kubeless/pkg/function-proxy/utils"
 	"github.com/kubeless/kubeless/pkg/functions"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -85,8 +83,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", handler)
 	mux.HandleFunc("/healthz", health)
-	mux.Handle("/metrics", promhttp.Handler())
-
+	mux.Handle("/metrics", proxyUtils.PromHTTPHandler())
 	server := proxyUtils.NewServer(mux)
 
 	go func() {


### PR DESCRIPTION
Issue Ref: https://github.com/kubeless/kubeless/issues/1020

Description: 
Exposed `promhttp.Handler` in a function in `kubeless/kubeless/pkg/function-proxy/utils/proxy-utils.go `and invoked that function here in `stable/golang/kubeless.tpl.go`.
There are some further changes in the `kubeless/kubeless repo`. 

Gave the script `compile-function.sh` the permission to run in the `Dockerfile`, otherwise the `compile` init-container of a kubeless function displays error status.  