### PR TITLE
Fix check for empty go.mod

### DIFF
--- a/stable/golang/compile-function.sh
+++ b/stable/golang/compile-function.sh
@@ -4,7 +4,8 @@ GO_VERSION="1.14"
 set -e
 
 # Copy function
-if [ ! -s "/kubeless/go.mod" ]; then
+if [[ -e "/kubeless/go.mod" && ! -s "/kubeless/go.mod" ]]; then
+  # Remove empty go.mod
   rm /kubeless/go.mod
 fi
 cp /kubeless/* /server/function/


### PR DESCRIPTION
Fixes check for empty go.mod file before removing it.

**Steps to reproduce**

```console
$ mkdir ~/kubeless
$ cd ~/kubeless
$ curl -L -o handler.go https://raw.githubusercontent.com/kubeless/runtimes/master/stable/golang/examples/helloget.go
$ docker run --rm -u root -v "$(pwd):/kubeless" kubeless/go-init:1.14 /compile-function.sh
rm: cannot remove '/kubeless/go.mod': No such file or directory
$ echo $?
1
```
**Steps to test**
```console
$ git clone --branch fix-golang-rm-go.mod https://github.com/sepetrov/runtimes.git ~/runtimes
$ cd ~/runtimes
$ docker build -f stable/golang/Dockerfile.1.14.init -t kubeless/go-init:1.14-fix stable/golang
$ docker run --rm -u root -v "$HOME/kubeless:/kubeless" -e "KUBELESS_FUNC_NAME=Foo" kubeless/go-init:1.14-fix /compile-function.sh
go: downloading github.com/kubeless/kubeless v1.0.7-0.20200406085802-2644ad500db0
go: downloading golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3
go: downloading github.com/prometheus/client_golang v0.9.1
go: downloading github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
go: downloading github.com/prometheus/common v0.2.0
go: downloading github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973
go: downloading github.com/prometheus/procfs v0.0.0-20190129233650-316cf8ccfec5
go: downloading github.com/golang/protobuf v1.2.0
go: downloading github.com/matttproud/golang_protobuf_extensions v1.0.1
go: found kubeless in kubeless v0.0.0-00010101000000-000000000000
$ echo $?
0
```

</details>