### PR TITLE
Bump kubeless version

### DIFF
--- a/stable/golang/server/go.mod
+++ b/stable/golang/server/go.mod
@@ -5,5 +5,5 @@ go 1.14
 replace kubeless => ./function
 
 require (
-	github.com/kubeless/kubeless 2644ad5
+	github.com/kubeless/kubeless v1.0.7
 )


### PR DESCRIPTION
Bumps kubeless version to latest stable tag v1.0.7