### PR TITLE
Change cp to cp -r for golang runtime

### DIFF
--- a/stable/golang/compile-function.sh
+++ b/stable/golang/compile-function.sh
@@ -8,7 +8,7 @@ if [[ -e "/kubeless/go.mod" && ! -s "/kubeless/go.mod" ]]; then
   # Remove empty go.mod
   rm /kubeless/go.mod
 fi
-cp /kubeless/* /server/function/
+cp -r /kubeless/* /server/function/
 
 # Replace FUNCTION placeholder
 sed "s/<<FUNCTION>>/${KUBELESS_FUNC_NAME}/g" /server/kubeless.go.tpl > /server/kubeless.go

--- a/stable/golang/golang.jsonnet
+++ b/stable/golang/golang.jsonnet
@@ -6,14 +6,14 @@
       version: "1.13",
       images: [{
         phase: "compilation",
-        image: "kubeless/go-init:1.13@sha256:7cdebecd772639c2238e6414101195cb8634c8eee73a6b473b7e39f3e094eb7c",
+        image: "kubeless/go-init:1.13@sha256:9161934a6333ff5932ec48933efe30fc988bbbff6e13e1c4eb6f3626e70390c7",
         command: "/compile-function.sh",
         env: {
           GOCACHE: "$(KUBELESS_INSTALL_VOLUME)/.cache",
         },
        }, {
         phase: "runtime",
-        image: "kubeless/go@sha256:55759228714d7080b3dd858e56530d4e1f539d071906e88d88b454ee3b3c9b16"
+        image: "kubeless/go@sha256:4048280138205d5ef2aa0dc4d169dca701e4df02d7feb42537cfd76ddef9c2b5"
       }],
     },
     {
@@ -21,14 +21,14 @@
       version: "1.14",
       images: [{
         phase: "compilation",
-        image: "kubeless/go-init:1.14@sha256:403164254efabf735e98e73b7f6f65f14333ed792798c7c3d3d9a33ca91acf7a",
+        image: "kubeless/go-init:1.14@sha256:1aeaf270961b0e5cdb9e5119bc1c1222b75d46d9d1311854ec37b4a842241219",
         command: "/compile-function.sh",
         env: {
           GOCACHE: "$(KUBELESS_INSTALL_VOLUME)/.cache",
         },
        }, {
         phase: "runtime",
-        image: "kubeless/go@sha256:55759228714d7080b3dd858e56530d4e1f539d071906e88d88b454ee3b3c9b16"
+        image: "kubeless/go@sha256:4048280138205d5ef2aa0dc4d169dca701e4df02d7feb42537cfd76ddef9c2b5"
       }],
     },
   ],


### PR DESCRIPTION
According to the [discussion here](https://github.com/kubeless/kubeless/issues/355#issuecomment-723349374), it should be fine to have a `cp -r` so that you can have multiple directories. 

Currently this `cp` fails to copy the files in subdirectories that you include in the `zip`, so the function fails to compile. 