### PR TITLE
#1190: Redirect output of Golang compilation to /dev/termination-log

### DIFF
--- a/stable/golang/compile-function.sh
+++ b/stable/golang/compile-function.sh
@@ -14,4 +14,6 @@ cp -r /kubeless/* /server/function/
 sed "s/<<FUNCTION>>/${KUBELESS_FUNC_NAME}/g" /server/kubeless.go.tpl > /server/kubeless.go
 # Build command
 cd /server
-GOOS=linux GOARCH=amd64 go build -o $KUBELESS_INSTALL_VOLUME/server .
+
+# Build the function and redirect stdout & stderr from the compilation step to the k8s output log
+GOOS=linux GOARCH=amd64 go build -o $KUBELESS_INSTALL_VOLUME/server . > /dev/termination-log 2>&1

--- a/stable/golang/golang.jsonnet
+++ b/stable/golang/golang.jsonnet
@@ -6,14 +6,14 @@
       version: "1.13",
       images: [{
         phase: "compilation",
-        image: "kubeless/go-init:1.13@sha256:9161934a6333ff5932ec48933efe30fc988bbbff6e13e1c4eb6f3626e70390c7",
+        image: "kubeless/go-init:1.13@sha256:1619c58b52e9e767a83dd4269206b4554eb008352af15ca00b25db8127520b8c",
         command: "/compile-function.sh",
         env: {
           GOCACHE: "$(KUBELESS_INSTALL_VOLUME)/.cache",
         },
        }, {
         phase: "runtime",
-        image: "kubeless/go@sha256:4048280138205d5ef2aa0dc4d169dca701e4df02d7feb42537cfd76ddef9c2b5"
+        image: "kubeless/go@sha256:ee496259f1bef2c338d074bfb5c14a08bb097f793a683d208a50df9f24d0d850"
       }],
     },
     {
@@ -21,14 +21,14 @@
       version: "1.14",
       images: [{
         phase: "compilation",
-        image: "kubeless/go-init:1.14@sha256:1aeaf270961b0e5cdb9e5119bc1c1222b75d46d9d1311854ec37b4a842241219",
+        image: "kubeless/go-init:1.14@sha256:b4b98c2848845447a43b50d61a386bcaa5bb34d5034a969aa404a41d71f1c439",
         command: "/compile-function.sh",
         env: {
           GOCACHE: "$(KUBELESS_INSTALL_VOLUME)/.cache",
         },
        }, {
         phase: "runtime",
-        image: "kubeless/go@sha256:4048280138205d5ef2aa0dc4d169dca701e4df02d7feb42537cfd76ddef9c2b5"
+        image: "kubeless/go@sha256:ee496259f1bef2c338d074bfb5c14a08bb097f793a683d208a50df9f24d0d850"
       }],
     },
   ],


### PR DESCRIPTION
When adding support for Go modules in [this commit](https://github.com/kubeless/runtimes/commit/4fcef10bda2dbe52beeaf6468eea422ec56d60cd#diff-428e5f5795b017b5da507840d53047096da5ec7d100bc3be2b0af6b1e6b96503L10), piping `stdout` and `stderr` to `/dev/termination-log` was removed. 

As discussed in [kubeless#1190](https://github.com/kubeless/kubeless/issues/1190), this re-adds this functionality. Alternatively, the documentation could be updated, but this is a nice feature to have. 