### PR TITLE
allow to specify strings as cherrypy num threads ENV variable

### DIFF
--- a/stable/python/_kubeless.py
+++ b/stable/python/_kubeless.py
@@ -190,5 +190,5 @@ if __name__ == '__main__':
         host='0.0.0.0',
         port=func_port,
         # Number of requests that can be handled in parallel (default = 10).
-        numthreads=os.getenv('CHERRYPY_NUMTHREADS', 10),
+        numthreads=int(os.getenv('CHERRYPY_NUMTHREADS', '10')),
     )

--- a/stable/python/python.jsonnet
+++ b/stable/python/python.jsonnet
@@ -10,7 +10,7 @@
         command: "pip install --prefix=$KUBELESS_INSTALL_VOLUME -r $KUBELESS_DEPS_FILE"
       }, {
         phase: "runtime",
-        image: "kubeless/python@sha256:ec5f3aea63b80002e4cdf7cd006ec5fb6d6329aa44b4a537ec559fb14b4e2411",
+        image: "kubeless/python@sha256:7e5b40d9109508c9600f3346492913f918d6b2bdb70da0d50dae1cb6c313dbcf",
         env: {
           PYTHONPATH: "$(KUBELESS_INSTALL_VOLUME)/lib/python3.6/site-packages:$(KUBELESS_INSTALL_VOLUME)",
         },
@@ -25,7 +25,7 @@
         command: "pip install --prefix=$KUBELESS_INSTALL_VOLUME -r $KUBELESS_DEPS_FILE"
       }, {
         phase: "runtime",
-        image: "kubeless/python@sha256:c5245959c1e2dae1642606e891e83a2ab87333755fce3b0685677836adfdcc6f",
+        image: "kubeless/python@sha256:da554547652c1bea35a0e97045861395456e642e8290c781def79cbd6dad0a96",
         env: {
           PYTHONPATH: "$(KUBELESS_INSTALL_VOLUME)/lib/python3.7/site-packages:$(KUBELESS_INSTALL_VOLUME)",
         },
@@ -40,7 +40,7 @@
         command: "pip install --prefix=$KUBELESS_INSTALL_VOLUME -r $KUBELESS_DEPS_FILE"
       }, {
         phase: "runtime",
-        image: "kubeless/python@sha256:efe867b7d1375e557d72487b068722211c4d8e08f9d0482f347c09046cc87872",
+        image: "kubeless/python@sha256:536eb97fda81d6e52bd947f771192077aa7b4f529fd0ca30e47561f94741963d",
         env: {
           PYTHONPATH: "$(KUBELESS_INSTALL_VOLUME)/lib/python3.8/site-packages:$(KUBELESS_INSTALL_VOLUME)",
         },


### PR DESCRIPTION
Kubernetes yaml files require ENV variables to be specified as strings, even if those are in fact numbers.

This makes it impossible (or is it my lack of knowledge?) to provide how many cherrypy threads we want in the python runtime while deploying functions via kubernetes yaml with ENV variables:
```
...
env:
- name: CHERRYPY_NUMTHREADS
   value: '2'
...
```

This is because cherrypy requires an integer, while kubernetes provides a string and an error is thrown.

This pull request solves that by changing the default value of cherrypy num threads to a string and then converting either that or the string provided from yaml into integer.
Of course changing of the default value to a string was not necessary but I think it better describes the purpose and intent.