### PR TITLE
stable/nodejs: replace npm w/ pnpm

### DIFF
--- a/stable/nodejs/Dockerfile.10
+++ b/stable/nodejs/Dockerfile.10
@@ -9,7 +9,8 @@ ADD kubeless-npm-install.sh /
 
 WORKDIR /kubeless_rt/
 
-RUN npm install
+RUN npm install -g pnpm \
+  && pnpm install
 
 USER 1000
 

--- a/stable/nodejs/Dockerfile.12
+++ b/stable/nodejs/Dockerfile.12
@@ -9,7 +9,8 @@ ADD kubeless-npm-install.sh /
 
 WORKDIR /kubeless_rt/
 
-RUN npm install
+RUN npm install -g pnpm \
+  && pnpm install
 
 USER 1000
 

--- a/stable/nodejs/Dockerfile.14
+++ b/stable/nodejs/Dockerfile.14
@@ -9,7 +9,8 @@ ADD kubeless-npm-install.sh /
 
 WORKDIR /kubeless_rt/
 
-RUN npm install
+RUN npm install -g pnpm \
+  && pnpm install
 
 USER 1000
 

--- a/stable/nodejs/kubeless-npm-install.sh
+++ b/stable/nodejs/kubeless-npm-install.sh
@@ -11,10 +11,10 @@ if [[ -n ${scope} ]]; then
 fi
 
 cd $KUBELESS_INSTALL_VOLUME
-npm config set ${scope}registry ${registry}
+pnpm config set ${scope}registry ${registry}
 
 if [[ -n ${NPM_CONFIG_EXTRA} ]]; then
-  npm config set ${NPM_CONFIG_EXTRA}
+  pnpm config set ${NPM_CONFIG_EXTRA}
 fi
 
-npm install --production --prefix=$KUBELESS_INSTALL_VOLUME
+pnpm install --prod --dir $KUBELESS_INSTALL_VOLUME


### PR DESCRIPTION
## Changes
The purpose of this change is to reduce the duration of pod/function provisioning by improving the performance of package installation.  Available resources still play their role, but `pnpm` can assist with better resource utilization.

Since [`pnpm`](https://pnpm.io/) is a drop-in replacement for `npm`, it does not require additional changes.

## Benchmarks
See https://pnpm.io/benchmarks for details on the following:

![image](https://user-images.githubusercontent.com/556053/117089452-9cbc9f80-ad23-11eb-8522-d6ac75e871e8.png)

@andresmgot @joek @Henrike42